### PR TITLE
Default gradient brushes to CanvasEdgeBehavior::Clamp

### DIFF
--- a/tests/CsConsumer/Shared/MainPage.xaml.cs
+++ b/tests/CsConsumer/Shared/MainPage.xaml.cs
@@ -123,7 +123,7 @@ namespace CsConsumer
             m_radialGradientBrush = new CanvasRadialGradientBrush(
                 sender, 
                 stops, 
-                CanvasEdgeBehavior.Wrap, 
+                CanvasEdgeBehavior.Clamp,
                 CanvasAlphaBehavior.Premultiplied);
         }
 

--- a/winrt/lib/Gradients.cpp
+++ b/winrt/lib/Gradients.cpp
@@ -79,7 +79,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         ComPtr<ID2D1GradientStopCollection1> stopCollection = deviceInternal->CreateGradientStopCollection(
             _countof(stops),
             stops,
-            CanvasEdgeBehavior::Wrap,
+            CanvasEdgeBehavior::Clamp,
             CanvasColorSpace::Srgb,
             CanvasColorSpace::Srgb,
             CanvasBufferPrecision::Precision8UIntNormalized,

--- a/winrt/test.external/CanvasBrushTests.cpp
+++ b/winrt/test.external/CanvasBrushTests.cpp
@@ -183,8 +183,10 @@ TEST_CLASS(CanvasBrushTests)
 
         CanvasLinearGradientBrush^ linearGradientBrush = CanvasLinearGradientBrush::CreateRainbow(device, 0.0f);
         Assert::AreEqual(7u, linearGradientBrush->Stops->Length);
+        Assert::IsTrue(linearGradientBrush->EdgeBehavior == CanvasEdgeBehavior::Clamp);
 
         CanvasRadialGradientBrush^ radialGradientBrush = CanvasRadialGradientBrush::CreateRainbow(device, 100.0f);
         Assert::AreEqual(7u, radialGradientBrush->Stops->Length);
+        Assert::IsTrue(radialGradientBrush->EdgeBehavior == CanvasEdgeBehavior::Clamp);
     }
 };


### PR DESCRIPTION
Fixes #25 by using `CanvasEdgeBehavior::Clamp`
