### PR TITLE
Removed "Divisor" from the countNeighbours effect.

### DIFF
--- a/tests/ExampleGallery/Shared/GameOfLife.xaml.cs
+++ b/tests/ExampleGallery/Shared/GameOfLife.xaml.cs
@@ -123,8 +123,7 @@ namespace ExampleGallery
             // Step 1: use a convolve matrix to count how many neighbors are alive. This filter
             // also includes the state of the current cell, but with a lower weighting. The result
             // is an arithmetic encoding where (value / 2) indicates how many neighbors are alive,
-            // and (value % 2) is the state of the cell itself. This is divided by 18 to make it
-            // fit within 0-1 color range.
+            // and (value % 2) is the state of the cell itself.
 
             countNeighborsEffect = new ConvolveMatrixEffect
             {
@@ -135,7 +134,6 @@ namespace ExampleGallery
                     2, 2, 2
                 },
 
-                Divisor = 18,
                 BorderMode = EffectBorderMode.Hard,
             };
 


### PR DESCRIPTION
This "Divisor" is apparently not needed (I tested it without the Divisor, and the code ran fine, and nothing in the subsequent transferTable depends on it having been divided).

Is it really necessary? Or is it just a holdover from an earlier testing phase when you visualized the output of countNeighborsEffect directly and didn't delete it?