### PR TITLE
Create WICBitmapDecoder using WICDecodeMetadataCacheOnDemand option value

### DIFF
--- a/winrt/lib/images/PolymorphicBitmapManager.cpp
+++ b/winrt/lib/images/PolymorphicBitmapManager.cpp
@@ -344,7 +344,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             ThrowIfFailed(m_wicFactory->CreateDecoderFromStream(
                 fileStream,
                 nullptr,
-                WICDecodeMetadataCacheOnLoad,
+				WICDecodeMetadataCacheOnDemand,
                 &wicBitmapDecoder));
 
             ComPtr<IWICBitmapFrameDecode> wicBitmapFrameSource;


### PR DESCRIPTION
Fixes bug #80. Loading an image should ignore unknown properties.