### PR TITLE
Prevent "Non-chronological" Error for Input Data

### DIFF
--- a/samples/ExampleGallery/Shared/CustomFonts.xaml.cs
+++ b/samples/ExampleGallery/Shared/CustomFonts.xaml.cs
@@ -138,8 +138,12 @@ namespace ExampleGallery
             args.Handled = true;
         }
 
+        ulong lastTimestamp = 0;
         private void Input_PointerMoved(object sender, PointerEventArgs args)      
         {
+             //we are not interested in multitouch, so interpret multiple events with same timestamp as one
+            if(args.CurrentPoint.Timestamp <= lastTimestamp) return;
+            lastTimestamp = args.CurrentPoint.Timestamp;
             gestureRecognizer.ProcessMoveEvents(args.GetIntermediatePoints());
             args.Handled = true;
         }


### PR DESCRIPTION
Prevents "(Input data cannot be processed in the non-chronological order)", since Input_PointerMoved gets fired with the same timestamp for every Pointer which is on the screen at the same time (e.g multitouch movement).

Not sure what to do if multiple fingers for multiple movements are needed (e.g. move multiple objects)