### PR TITLE
Fixed a bad usage of WRL HStringReference

### DIFF
--- a/winrt/lib/effects/CanvasEffect.cpp
+++ b/winrt/lib/effects/CanvasEffect.cpp
@@ -20,8 +20,8 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         m_sources->SetChanged(true);
 
         // Create propertyValueFactory
-        HSTRING stringActivableClassId = Wrappers::HStringReference(RuntimeClass_Windows_Foundation_PropertyValue).Get();
-        ThrowIfFailed(GetActivationFactory(stringActivableClassId, &m_propertyValueFactory));
+        Wrappers::HStringReference stringActivableClassId(RuntimeClass_Windows_Foundation_PropertyValue);
+        ThrowIfFailed(GetActivationFactory(stringActivableClassId.Get(), &m_propertyValueFactory));
     }
 
     //


### PR DESCRIPTION
A temporary-storage HStringReference object was used to obtain an HSTRING handle, but the object's lifetime ended before the HSTRING was used, which is undefined behavior.