### PR TITLE
Added overloads of CanvasBitmap methods, which operator on IMemoryBufferReference

### DIFF
--- a/winrt/docsrc/CanvasBitmap.xml
+++ b/winrt/docsrc/CanvasBitmap.xml
@@ -170,6 +170,18 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
       <summary>Creates a CanvasBitmap from the bytes of the specified buffer, using the specified pixel width/height, DPI and alpha behavior.</summary>
       <remarks>List of <a href="PixelFormats.htm">supported pixel formats</a>.</remarks>
     </member>
+	<member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.CreateFromBytes(Microsoft.Graphics.Canvas.ICanvasResourceCreator,Windows.Foundation.IMemoryBufferReference,System.Int32,System.Int32,Windows.Graphics.DirectX.DirectXPixelFormat)">
+      <summary>Creates a CanvasBitmap from the bytes of the specified buffer, using the specified pixel width/height, premultiplied alpha and default (96) DPI.</summary>
+      <remarks>List of <a href="PixelFormats.htm">supported pixel formats</a>.</remarks>
+    </member>
+    <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.CreateFromBytes(Microsoft.Graphics.Canvas.ICanvasResourceCreator,Windows.Foundation.IMemoryBufferReference,System.Int32,System.Int32,Windows.Graphics.DirectX.DirectXPixelFormat,System.Single)">
+      <summary>Creates a CanvasBitmap from the bytes of the specified buffer, using the specified pixel width/height, specified DPI, and premultiplied alpha.</summary>
+      <remarks>List of <a href="PixelFormats.htm">supported pixel formats</a>.</remarks>
+    </member>
+    <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.CreateFromBytes(Microsoft.Graphics.Canvas.ICanvasResourceCreator,Windows.Foundation.IMemoryBufferReference,System.Int32,System.Int32,Windows.Graphics.DirectX.DirectXPixelFormat,System.Single,Microsoft.Graphics.Canvas.CanvasAlphaMode)">
+      <summary>Creates a CanvasBitmap from the bytes of the specified buffer, using the specified pixel width/height, DPI and alpha behavior.</summary>
+      <remarks>List of <a href="PixelFormats.htm">supported pixel formats</a>.</remarks>
+    </member>
     <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.CreateFromColors(Microsoft.Graphics.Canvas.ICanvasResourceCreator,Windows.UI.Color[],System.Int32,System.Int32)">
       <summary>Creates a CanvasBitmap from an array of colors, using the specified pixel width/height, premultiplied alpha and default (96) DPI.</summary>
     </member>
@@ -394,6 +406,57 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
         </ul>
       </remarks>    
     </member>
+	<member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.GetPixelBytes(Windows.Foundation.IMemoryBufferReference)">
+      <summary>Copies raw byte data for the entire bitmap into the specified buffer.</summary>
+      <remarks>
+        <ul>
+          <li>
+            Works on bitmaps of any format.
+          </li>
+          <li>
+            For uncompressed texture formats, the capacity of the buffer must be
+            at least SizeInPixels.Width * SizeInPixels.Height * (bytes per
+            pixel).  The number of bytes per pixel is determined by <see
+            cref="P:Microsoft.Graphics.Canvas.CanvasBitmap.Format"/>. For a
+            CanvasBitmap with the default format of
+            DirectXPixelFormat.B8G8R8A8UintNormalized this is 4.
+          </li>
+          <li>
+            For block compressed texture formats, the capacity of the buffer must be
+            at least SizeInPixels.Width * SizeInPixels.Height * (bytes per
+            block) / 16. See <a href="BlockCompression.htm">Bitmap block
+            compression</a> page for more information.
+          </li>
+        </ul>
+      </remarks>
+    </member>
+    <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.GetPixelBytes(Windows.Foundation.IMemoryBufferReference,System.Int32,System.Int32,System.Int32,System.Int32)">
+      <summary>Copies raw byte data for a subregion of the bitmap into the specified buffer.</summary>
+      <remarks>
+        <ul>
+          <li>
+            Works on bitmaps of any format.
+          </li>
+          <li>
+            left, top, width and height are specified in pixels (not DIPs).
+          </li>
+          <li>
+            For uncompressed texture formats, the capacity of the buffer must be
+            at least width * height * (bytes per pixel).  The number of bytes
+            per pixel is determined by <see
+            cref="P:Microsoft.Graphics.Canvas.CanvasBitmap.Format"/>. For a
+            CanvasBitmap with the default format of
+            DirectXPixelFormat.B8G8R8A8UintNormalized this is 4.
+          </li>
+          <li>
+            For block compressed texture formats, the capacity of the buffer must be
+            at least width * height * (bytes per block) / 16. See <a
+            href="BlockCompression.htm">Bitmap block compression</a> page for
+            more information.
+          </li>
+        </ul>
+      </remarks>    
+    </member>
     <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.GetPixelColors">
       <summary>Returns an array of color data for the entire bitmap.</summary>
       <remarks>
@@ -502,6 +565,57 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
       </remarks>
     </member>
     <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.SetPixelBytes(Windows.Storage.Streams.IBuffer,System.Int32,System.Int32,System.Int32,System.Int32)">
+      <summary>Sets the byte data of a subregion of the bitmap from the specified buffer.</summary>
+      <remarks>
+        <ul>
+          <li>
+            Works on bitmaps of any format.
+          </li>
+          <li>
+            left, top, width and height are specified in pixels (not DIPs).
+          </li>
+          <li>
+            For uncompressed texture formats, the length of the buffer must be
+            at least width * height * (bytes per
+            pixel).  The number of bytes per pixel is determined by <see
+            cref="P:Microsoft.Graphics.Canvas.CanvasBitmap.Format"/>. For a
+            CanvasBitmap with the default format of
+            DirectXPixelFormat.B8G8R8A8UintNormalized this is 4.
+          </li>
+          <li>
+            For block compressed texture formats, the length of the buffer must be
+            at least width * height * (bytes per
+            block) / 16. See <a href="BlockCompression.htm">Bitmap block
+            compression</a> page for more information.
+          </li>
+        </ul>
+      </remarks>
+    </member>
+	<member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.SetPixelBytes(Windows.Foundation.IMemoryBufferReference)">
+      <summary>Sets the byte data of the bitmap from the specified buffer.</summary>
+      <remarks>
+        <ul>
+          <li>
+            Works on bitmaps of any format.
+          </li>
+          <li>
+            For uncompressed texture formats, the length of the buffer must be
+            at least SizeInPixels.Width * SizeInPixels.Height * (bytes per
+            pixel).  The number of bytes per pixel is determined by <see
+            cref="P:Microsoft.Graphics.Canvas.CanvasBitmap.Format"/>. For a
+            CanvasBitmap with the default format of
+            DirectXPixelFormat.B8G8R8A8UintNormalized this is 4.
+          </li>
+          <li>
+            For block compressed texture formats, the length of the buffer must be
+            at least SizeInPixels.Width * SizeInPixels.Height * (bytes per
+            block) / 16. See <a href="BlockCompression.htm">Bitmap block
+            compression</a> page for more information.
+          </li>
+        </ul>
+      </remarks>
+    </member>
+    <member name="M:Microsoft.Graphics.Canvas.CanvasBitmap.SetPixelBytes(Windows.Foundation.IMemoryBufferReference,System.Int32,System.Int32,System.Int32,System.Int32)">
       <summary>Sets the byte data of a subregion of the bitmap from the specified buffer.</summary>
       <remarks>
         <ul>

--- a/winrt/lib/images/CanvasBitmap.abi.idl
+++ b/winrt/lib/images/CanvasBitmap.abi.idl
@@ -109,17 +109,31 @@ namespace Microsoft.Graphics.Canvas
             [out] UINT32* valueCount,
             [out, size_is(, *valueCount), retval] BYTE** valueElements);
 
-        [overload("GetPixelBytes")]
+        [overload("GetPixelBytes"), default_overload]
         HRESULT GetPixelBytesWithBuffer(
             [in] Windows.Storage.Streams.IBuffer* buffer);
 
-        [overload("GetPixelBytes")]
+        [overload("GetPixelBytes"), default_overload]
         HRESULT GetPixelBytesWithBufferAndSubrectangle(
             [in] Windows.Storage.Streams.IBuffer* buffer,
             [in] INT32 left,
             [in] INT32 top,
             [in] INT32 width,
             [in] INT32 height);
+
+#if WINVER > _WIN32_WINNT_WINBLUE
+		[overload("GetPixelBytes")]
+		HRESULT GetPixelBytesWithMemoryBufferReference(
+			[in] Windows.Foundation.IMemoryBufferReference* buffer);
+
+		[overload("GetPixelBytes")]
+		HRESULT GetPixelBytesWithMemoryBufferReferenceAndSubrectangle(
+			[in] Windows.Foundation.IMemoryBufferReference* buffer,
+			[in] INT32 left,
+			[in] INT32 top,
+			[in] INT32 width,
+			[in] INT32 height);
+#endif
 
         [overload("GetPixelColors")]
         HRESULT GetPixelColors(
@@ -160,6 +174,20 @@ namespace Microsoft.Graphics.Canvas
             [in] INT32 top,
             [in] INT32 width,
             [in] INT32 height);
+
+#if WINVER > _WIN32_WINNT_WINBLUE
+		[overload("SetPixelBytes")]
+		HRESULT SetPixelBytesWithMemoryBufferReference(
+			[in] Windows.Foundation.IMemoryBufferReference* buffer);
+
+		[overload("SetPixelBytes")]
+		HRESULT SetPixelBytesWithMemoryBufferReferenceAndSubrectangle(
+			[in] Windows.Foundation.IMemoryBufferReference* buffer,
+			[in] INT32 left,
+			[in] INT32 top,
+			[in] INT32 width,
+			[in] INT32 height);
+#endif
 
         [overload("SetPixelColors")]
         HRESULT SetPixelColors(
@@ -282,6 +310,38 @@ namespace Microsoft.Graphics.Canvas
             [in] float dpi,
             [in] CanvasAlphaMode alpha,
             [out, retval] CanvasBitmap** bitmap);
+
+#if WINVER > _WIN32_WINNT_WINBLUE
+		[overload("CreateFromBytes")]
+		HRESULT CreateFromBytesWithMemoryBufferReference(
+			[in] ICanvasResourceCreator* resourceCreator,
+			[in] Windows.Foundation.IMemoryBufferReference* buffer,
+			[in] INT32 widthInPixels,
+			[in] INT32 heightInPixels,
+			[in] DIRECTX_PIXEL_FORMAT format,
+			[out, retval] CanvasBitmap** bitmap);
+
+		[overload("CreateFromBytes")]
+		HRESULT CreateFromBytesWithMemoryBufferReferenceAndDpi(
+			[in] ICanvasResourceCreator* resourceCreator,
+			[in] Windows.Foundation.IMemoryBufferReference* buffer,
+			[in] INT32 widthInPixels,
+			[in] INT32 heightInPixels,
+			[in] DIRECTX_PIXEL_FORMAT format,
+			[in] float dpi,
+			[out, retval] CanvasBitmap** bitmap);
+
+		[overload("CreateFromBytes")]
+		HRESULT CreateFromBytesWithMemoryBufferReferenceAndDpiAndAlpha(
+			[in] ICanvasResourceCreator* resourceCreator,
+			[in] Windows.Foundation.IMemoryBufferReference* buffer,
+			[in] INT32 widthInPixels,
+			[in] INT32 heightInPixels,
+			[in] DIRECTX_PIXEL_FORMAT format,
+			[in] float dpi,
+			[in] CanvasAlphaMode alpha,
+			[out, retval] CanvasBitmap** bitmap);
+#endif
 
         [overload("CreateFromColors")]
         HRESULT CreateFromColors(

--- a/winrt/lib/images/CanvasBitmap.h
+++ b/winrt/lib/images/CanvasBitmap.h
@@ -197,6 +197,35 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             CanvasAlphaMode alpha,
             ICanvasBitmap** canvasBitmap) override;
 
+#if WINVER > _WIN32_WINNT_WINBLUE
+		IFACEMETHOD(CreateFromBytesWithMemoryBufferReference)(
+			ICanvasResourceCreator* resourceCreator,
+			IMemoryBufferReference* buffer,
+			int32_t widthInPixels,
+			int32_t heightInPixels,
+			DirectXPixelFormat format,
+			ICanvasBitmap** canvasBitmap) override;
+
+		IFACEMETHOD(CreateFromBytesWithMemoryBufferReferenceAndDpi)(
+			ICanvasResourceCreator* resourceCreator,
+			IMemoryBufferReference* buffer,
+			int32_t widthInPixels,
+			int32_t heightInPixels,
+			DirectXPixelFormat format,
+			float dpi,
+			ICanvasBitmap** canvasBitmap) override;
+
+		IFACEMETHOD(CreateFromBytesWithMemoryBufferReferenceAndDpiAndAlpha)(
+			ICanvasResourceCreator* resourceCreator,
+			IMemoryBufferReference* buffer,
+			int32_t widthInPixels,
+			int32_t heightInPixels,
+			DirectXPixelFormat format,
+			float dpi,
+			CanvasAlphaMode alpha,
+			ICanvasBitmap** canvasBitmap) override;
+#endif
+
         IFACEMETHOD(CreateFromColors)(
             ICanvasResourceCreator* resourceCreator,
             uint32_t colorCount,
@@ -308,6 +337,14 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         D2D1_RECT_U const& subRectangle,
         IBuffer* buffer);
 
+#if WINVER > _WIN32_WINNT_WINBLUE
+	void GetPixelBytesImpl(
+		ComPtr<ICanvasDevice> const& device,
+		ComPtr<ID2D1Bitmap1> const& d2dBitmap,
+		D2D1_RECT_U const& subRectangle,
+		IMemoryBufferReference* buffer);
+#endif
+
     void GetPixelColorsImpl(
         ComPtr<ICanvasDevice> const& device,
         ComPtr<ID2D1Bitmap1> const& d2dBitmap,
@@ -341,6 +378,13 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         ComPtr<ID2D1Bitmap1> const& d2dBitmap,
         D2D1_RECT_U const& subRectangle,
         IBuffer* buffer);
+
+#if WINVER > _WIN32_WINNT_WINBLUE
+	void SetPixelBytesImpl(
+		ComPtr<ID2D1Bitmap1> const& d2dBitmap,
+		D2D1_RECT_U const& subRectangle,
+		IMemoryBufferReference* buffer);
+#endif
 
     void SetPixelColorsImpl(
         ComPtr<ID2D1Bitmap1> const& d2dBitmap,
@@ -717,6 +761,44 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 });
         }
 
+#if WINVER > _WIN32_WINNT_WINBLUE
+		IFACEMETHODIMP GetPixelBytesWithMemoryBufferReference(
+			IMemoryBufferReference* buffer) override
+		{
+			return ExceptionBoundary(
+				[&]
+			{
+				auto& d2dBitmap = GetResource();
+
+				GetPixelBytesImpl(
+					m_device,
+					d2dBitmap,
+					GetResourceBitmapExtents(d2dBitmap),
+					buffer);
+			});
+		}
+
+		IFACEMETHODIMP GetPixelBytesWithMemoryBufferReferenceAndSubrectangle(
+			IMemoryBufferReference* buffer,
+			int32_t left,
+			int32_t top,
+			int32_t width,
+			int32_t height) override
+		{
+			return ExceptionBoundary(
+				[&]
+			{
+				auto& d2dBitmap = GetResource();
+
+				GetPixelBytesImpl(
+					m_device,
+					d2dBitmap,
+					ToD2DRectU(left, top, width, height),
+					buffer);
+			});
+		}
+#endif
+
         IFACEMETHODIMP GetPixelColors(
             uint32_t* valueCount,
             ABI::Windows::UI::Color **valueElements) override
@@ -828,6 +910,42 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                         buffer);
                 });
         }
+
+#if WINVER > _WIN32_WINNT_WINBLUE
+		IFACEMETHODIMP SetPixelBytesWithMemoryBufferReference(
+			IMemoryBufferReference* buffer) override
+		{
+			return ExceptionBoundary(
+				[&]
+			{
+				auto& d2dBitmap = GetResource();
+
+				SetPixelBytesImpl(
+					d2dBitmap,
+					GetResourceBitmapExtents(d2dBitmap),
+					buffer);
+			});
+		}
+
+		IFACEMETHODIMP SetPixelBytesWithMemoryBufferReferenceAndSubrectangle(
+			IMemoryBufferReference* buffer,
+			int32_t left,
+			int32_t top,
+			int32_t width,
+			int32_t height) override
+		{
+			return ExceptionBoundary(
+				[&]
+			{
+				auto& d2dBitmap = GetResource();
+
+				SetPixelBytesImpl(
+					d2dBitmap,
+					ToD2DRectU(left, top, width, height),
+					buffer);
+			});
+		}
+#endif
 
         IFACEMETHODIMP SetPixelColors(
             uint32_t valueCount,

--- a/winrt/test.managed/Shared/CanvasBitmapTests.cs
+++ b/winrt/test.managed/Shared/CanvasBitmapTests.cs
@@ -13,7 +13,7 @@ using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.Streams;
 using Windows.UI;
-
+using Buffer = Windows.Storage.Streams.Buffer;
 #if WINDOWS_UWP
 using Windows.Graphics.DirectX;
 #else
@@ -130,7 +130,7 @@ namespace test.managed
             // Too small a buffer.
             Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(device, buffer, 3, 3, DirectXPixelFormat.A8UIntNormalized));
         }
-
+        
         [TestMethod]
         public void SetPixelBytesUsingBuffer()
         {
@@ -213,6 +213,157 @@ namespace test.managed
             Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteBuffer, 0, 0, 0, 1));
             Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteBuffer, 0, 0, 1, 0));
         }
+
+#if WINDOWS_UWP
+        [TestMethod]
+        public void CreateFromIMemoryBufferReference()
+        {
+            var device = new CanvasDevice();
+
+            byte[] somePixelData = { 1, 2, 3, 4 };
+
+            var buffer = somePixelData.AsBuffer();
+            var memoryBuffer = Buffer.CreateMemoryBufferOverIBuffer(buffer);
+            var memoryBufferReference = memoryBuffer.CreateReference();
+
+            // Overload #1
+            var bitmap = CanvasBitmap.CreateFromBytes(device, memoryBufferReference, 2, 2, DirectXPixelFormat.A8UIntNormalized);
+
+            Assert.AreEqual(2u, bitmap.SizeInPixels.Width);
+            Assert.AreEqual(2u, bitmap.SizeInPixels.Height);
+            Assert.AreEqual(96, bitmap.Dpi);
+            Assert.AreEqual(DirectXPixelFormat.A8UIntNormalized, bitmap.Format);
+            Assert.AreEqual(CanvasAlphaMode.Premultiplied, bitmap.AlphaMode);
+
+            CollectionAssert.AreEqual(somePixelData, bitmap.GetPixelBytes());
+
+            // Overload #2
+            const float someDpi = 123.0f;
+
+            bitmap = CanvasBitmap.CreateFromBytes(device, memoryBufferReference, 2, 2, DirectXPixelFormat.A8UIntNormalized, someDpi);
+
+            Assert.AreEqual(2u, bitmap.SizeInPixels.Width);
+            Assert.AreEqual(2u, bitmap.SizeInPixels.Height);
+            Assert.AreEqual(someDpi, bitmap.Dpi);
+            Assert.AreEqual(DirectXPixelFormat.A8UIntNormalized, bitmap.Format);
+            Assert.AreEqual(CanvasAlphaMode.Premultiplied, bitmap.AlphaMode);
+
+            CollectionAssert.AreEqual(somePixelData, bitmap.GetPixelBytes());
+
+            // Overload #3
+            bitmap = CanvasBitmap.CreateFromBytes(device, memoryBufferReference, 2, 2, DirectXPixelFormat.A8UIntNormalized, someDpi, CanvasAlphaMode.Straight);
+
+            Assert.AreEqual(2u, bitmap.SizeInPixels.Width);
+            Assert.AreEqual(2u, bitmap.SizeInPixels.Height);
+            Assert.AreEqual(someDpi, bitmap.Dpi);
+            Assert.AreEqual(DirectXPixelFormat.A8UIntNormalized, bitmap.Format);
+            Assert.AreEqual(CanvasAlphaMode.Straight, bitmap.AlphaMode);
+
+            CollectionAssert.AreEqual(somePixelData, bitmap.GetPixelBytes());
+
+            // Null device.
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(null, memoryBufferReference, 2, 2, DirectXPixelFormat.A8UIntNormalized));
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(null, memoryBufferReference, 2, 2, DirectXPixelFormat.A8UIntNormalized, someDpi));
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(null, memoryBufferReference, 2, 2, DirectXPixelFormat.A8UIntNormalized, someDpi, CanvasAlphaMode.Straight));
+
+            // Null buffer.
+            IMemoryBufferReference nullBuffer = null;
+
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(device, nullBuffer, 2, 2, DirectXPixelFormat.A8UIntNormalized));
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(device, nullBuffer, 2, 2, DirectXPixelFormat.A8UIntNormalized, someDpi));
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(device, nullBuffer, 2, 2, DirectXPixelFormat.A8UIntNormalized, someDpi, CanvasAlphaMode.Straight));
+
+            // Too small a buffer.
+            Assert.ThrowsException<ArgumentException>(() => CanvasBitmap.CreateFromBytes(device, memoryBufferReference, 3, 3, DirectXPixelFormat.A8UIntNormalized));
+        }
+        
+        [TestMethod]
+        public void SetPixelBytesUsingIMemoryBufferReference()
+        {
+            var device = new CanvasDevice();
+            var bitmap = CanvasBitmap.CreateFromBytes(device, new byte[4], 2, 2, DirectXPixelFormat.A8UIntNormalized);
+
+            // SetPixelBytes(buffer)
+            var buffer = new byte[] { 1, 2, 3, 4 }.AsBuffer();
+            var memoryBuffer = Buffer.CreateMemoryBufferOverIBuffer(buffer);
+            bitmap.SetPixelBytes(memoryBuffer.CreateReference());
+
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, bitmap.GetPixelBytes());
+
+            // SetPixelBytes(buffer, rectangle)
+            buffer = new byte[] { 5, 6 }.AsBuffer();
+            memoryBuffer = Buffer.CreateMemoryBufferOverIBuffer(buffer);
+            bitmap.SetPixelBytes(memoryBuffer.CreateReference(), 1, 0, 1, 2);
+
+            CollectionAssert.AreEqual(new byte[] { 1, 5, 3, 6 }, bitmap.GetPixelBytes());
+
+            // Null buffer.
+            IMemoryBufferReference nullBuffer = null;
+
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(nullBuffer));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(nullBuffer, 0, 0, 1, 1));
+
+            // Too small buffer.
+            buffer = new byte[1].AsBuffer();
+            memoryBuffer = Buffer.CreateMemoryBufferOverIBuffer(buffer);
+            var oneByteMemoryBufferReference = memoryBuffer.CreateReference();
+
+            Utils.AssertThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference), "The array was expected to be of size 4; actual array was of size 1.");
+            Utils.AssertThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, 1, 0, 1, 2), "The array was expected to be of size 2; actual array was of size 1.");
+
+            // Bad rectangles.
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, -1, 0, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, 0, -1, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, 2, 0, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, 0, 2, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, 0, 0, 0, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.SetPixelBytes(oneByteMemoryBufferReference, 0, 0, 1, 0));
+        }
+
+        [TestMethod]
+        public void GetPixelBytesUsingIMemoryBufferReference()
+        {
+            var device = new CanvasDevice();
+            var bitmap = CanvasBitmap.CreateFromBytes(device, new byte[4] { 1, 2, 3, 4 }, 2, 2, DirectXPixelFormat.A8UIntNormalized);
+
+            var array = new byte[4];
+            var buffer = array.AsBuffer();
+            var memoryBuffer = Buffer.CreateMemoryBufferOverIBuffer(buffer);
+            var memoryBufferReference = memoryBuffer.CreateReference();
+
+            // GetPixelBytes(buffer)
+            bitmap.GetPixelBytes(memoryBufferReference);
+            
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, array);
+
+            // GetPixelBytes(buffer, rectangle)
+            bitmap.GetPixelBytes(memoryBufferReference, 1, 0, 1, 2);
+
+            CollectionAssert.AreEqual(new byte[] { 2, 4, 3, 4 }, array);
+
+            // Null buffer.
+            IMemoryBufferReference nullBuffer = null;
+
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(nullBuffer));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(nullBuffer, 0, 0, 1, 1));
+
+            // Too small buffer.
+            buffer = new byte[1].AsBuffer();
+            memoryBuffer = Buffer.CreateMemoryBufferOverIBuffer(buffer);
+            var oneByteMemoryBufferReference = memoryBuffer.CreateReference();
+
+            Utils.AssertThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference), "The array was expected to be of size 4; actual array was of size 1.");
+            Utils.AssertThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, 1, 0, 1, 2), "The array was expected to be of size 2; actual array was of size 1.");
+
+            // Bad rectangles.
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, -1, 0, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, 0, -1, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, 2, 0, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, 0, 2, 1, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, 0, 0, 0, 1));
+            Assert.ThrowsException<ArgumentException>(() => bitmap.GetPixelBytes(oneByteMemoryBufferReference, 0, 0, 1, 0));
+        }
+#endif
 
         [TestMethod]
         public void SetPixelBytesReadHazards()


### PR DESCRIPTION
This pull request adds the overloads of CanvasBitmap.CreateFromBytes, CanvasBitmap.SetPixelBytes and CanvasBitmap.GetPixelBytes methods, which operate on IMemoryReference, and the corresponding unit tests. I believe these might be useful.

I'm not sure if I need to add an additional parameter for the starting index. Does Windows Runtime expose any API, like multiplane textures, which may require passing the starting index?

By the way, thank you for Win2D! This project saved lots of my time.