### PR TITLE
Update print preview when switching printers

### DIFF
--- a/samples/ExampleGallery/Shared/PrintingExample.xaml.cs
+++ b/samples/ExampleGallery/Shared/PrintingExample.xaml.cs
@@ -121,8 +121,18 @@ namespace ExampleGallery
             displayedOptions.Add(StandardPrintTaskOptions.MediaSize);
             displayedOptions.Add(StandardPrintTaskOptions.Orientation);
             displayedOptions.Add("PageRange");
+
+            detailedOptions.OptionChanged += PrintDetailedOptions_OptionChanged;
         }
 
+        private void PrintDetailedOptions_OptionChanged(PrintTaskOptionDetails sender, PrintTaskOptionChangedEventArgs args)
+        {
+            if (args.OptionId == null)
+            {
+                // Invalidate the preview when switching printers.
+                this.printDocument.InvalidatePreview();
+            }
+        }
 
         private async void PrintDocument_PrintTaskOptionsChanged(CanvasPrintDocument sender, CanvasPrintTaskOptionsChangedEventArgs args)
         {


### PR DESCRIPTION
If you switch printers the print preview doesn't update until you change
another property like Orientation. This is noticeable when switch from
something like print to PDF which has no margins to a physical printer
that does. (bug #292)

Fix is to listen to OptionChanged and invalidate the preview when an
event with a null OptionId is raised.