### PR TITLE
Fixed #373: Added Measure() call to the canvas control.

### DIFF
--- a/samples/ExampleGallery/Shared/GlowTextCustomControl.cs
+++ b/samples/ExampleGallery/Shared/GlowTextCustomControl.cs
@@ -121,7 +121,7 @@ namespace ExampleGallery
             {
                 instance.canvas.Invalidate();
                 instance.InvalidateMeasure();
-            }            
+            }
         }
 
         // This is the amount that we grow the desired size by (to account for the glow)
@@ -142,7 +142,11 @@ namespace ExampleGallery
             var layout = CreateTextLayout(device, availableSize);
             var bounds = layout.LayoutBounds;
 
-            return new Size(Math.Min(availableSize.Width, bounds.Width + ExpandAmount), Math.Min(availableSize.Height, bounds.Height + ExpandAmount));
+            Size desiredSize = new Size(Math.Min(availableSize.Width, bounds.Width + ExpandAmount), Math.Min(availableSize.Height, bounds.Height + ExpandAmount));
+            if (canvas != null)
+                canvas.Measure(desiredSize);
+
+            return desiredSize;
         }
 
         private void OnDraw(CanvasControl sender, CanvasDrawEventArgs args)


### PR DESCRIPTION
Added a call to ```canvas.Measure()``` to the GlowTextCustomControl. As discussed in Issue #373 .