### PR TITLE
Ensure CanvasVirtualControl gets initialized on CoreWindow.WindowVisibilityChanged event.

### DIFF
--- a/winrt/lib/xaml/CanvasVirtualControl.cpp
+++ b/winrt/lib/xaml/CanvasVirtualControl.cpp
@@ -408,6 +408,10 @@ void CanvasVirtualControl::WindowVisibilityChanged()
         {
             ThrowIfFailed(imageSource->RaiseRegionsInvalidatedIfAny());
         }
+        else
+        {
+            Changed(ChangeReason::Other);
+        }
     }
 }
 


### PR DESCRIPTION
This fix has been verified to work in few of our scenarios (multiple windows, lazy loading, etc.).