### PR TITLE
Fix AV when a non-existent element is passed to CanvasSvgDocument.FindElementByID

### DIFF
--- a/winrt/docsrc/CanvasSvgDocument.xml
+++ b/winrt/docsrc/CanvasSvgDocument.xml
@@ -198,6 +198,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
 
     <member name="M:Microsoft.Graphics.Canvas.Svg.CanvasSvgDocument.FindElementById(System.String)">
       <summary>Finds the element in this document which has the specified ID.</summary>
+      <remarks>If the ID doesn't exist, FindElementById will produce an error.</remarks>
     </member>
     <member name="M:Microsoft.Graphics.Canvas.Svg.CanvasSvgDocument.CreatePaintAttribute">
       <summary>Creates an attribute that can be used for a stroke or fill value.</summary>

--- a/winrt/lib/svg/CanvasSvgDocument.cpp
+++ b/winrt/lib/svg/CanvasSvgDocument.cpp
@@ -258,6 +258,9 @@ IFACEMETHODIMP CanvasSvgDocument::FindElementById(HSTRING elementName, ICanvasSv
             ComPtr<ID2D1SvgElement> d2dFoundElement;
             ThrowIfFailed(resource->FindElementById(GetStringBuffer(elementName), &d2dFoundElement));
 
+            if (!d2dFoundElement)
+                ThrowHR(E_INVALIDARG);
+
             ComPtr<ICanvasSvgNamedElement> wrapped = ResourceManager::GetOrCreate<ICanvasSvgNamedElement>(device.Get(), d2dFoundElement.Get());
             ThrowIfFailed(wrapped.CopyTo(foundElement));
         });

--- a/winrt/test.external/CanvasSvgDocumentTests.cpp
+++ b/winrt/test.external/CanvasSvgDocumentTests.cpp
@@ -378,6 +378,20 @@ public:
         Assert::AreEqual(document->Root, found);
     }
 
+    TEST_METHOD(CanvasSvgDocument_FindElementById_ElementNotThere)
+    {
+        if (!m_isSupported)
+            return;
+
+        auto document = CanvasSvgDocument::LoadFromXml(m_device, "<svg/>");
+        
+        Assert::ExpectException<Platform::InvalidArgumentException^>(
+            [&]
+            {
+                document->FindElementById("something");
+            });
+    }
+
     TEST_METHOD(CanvasSvgDocument_DOM_Manipulation)
     {
         if (!m_isSupported)


### PR DESCRIPTION
This is for fixing issue #628 - "CanvasSvgDocument FindElementById method throws System.AccessViolationException".