### PR TITLE
Adding WORKAROUNDs for VS issues to XAML island sample

### DIFF
--- a/samples/XamlIslandSample/README.md
+++ b/samples/XamlIslandSample/README.md
@@ -45,10 +45,12 @@ To debug the Win2D components select `Mixed (Managed and Native)` under Debug / 
 
 The current preview package has some support for using Win2D in XAML Islands but there are some manual steps to be done
 1. At the moment the NuGet package is not published so you have to build a local Win2D package from this branch. See https://github.com/Microsoft/Win2D#building-win2d-from-source for details.
-2. Create a .NET Core WPF app that references the Win2D NuGet package along with a Windows Application Packaging Project. An appx / msix package is necessary to run any UWP XAML UI. This package can be installed from the store or sideloaded.
+2. Create a .NET Core WPF app that references the Win2D NuGet package along with a Windows Application Packaging Project. An appx / msix package is necessary to run any third party WinRT Components like Win2D. This package can be sideloaded or installed from the store.
 3. You have to **tweak both project files** manually (details below). This will probably change in the future.
    - The WPF app needs to get built self-contained (everything included in the appx) and therefore needs to know which runtime should be included.
    - The appx must reference the VC Runtime. There is no way for this reference to flow from the Win2D NuGet package via the app to the appx project automatically.
+   - WORKAROUND: The project .deps.json file is needed at runtime by a .NET Core app but gets not deployed.
+   - WORKAROUND: At startup the .NET Core app looks up all references in another directory as WinMD files are deployed.
 4. Add code that targets Win2D components. Maybe you want to reference `Microsoft.Toolkit.Wpf.UI.XamlHost` and add some XAML UI (like in https://github.com/Microsoft/Win2D/tree/xaml_islands/samples/XamlIslandSample) or you create a XAML island by your own. To smoke test the deployment you can add
     ```csharp
     Windows.UI.Xaml.Hosting.WindowsXamlManager.InitializeForCurrentThread();
@@ -69,24 +71,40 @@ The current preview package has some support for using Win2D in XAML Islands but
     *NOTE*: Alternative you can add the local source to NuGet Package Manager Settings in VS
 - `dotnet new wpf -n wpfapp`
 - Add this to `wpfapp\wpfapp.csproj`
-	```xml
-    <PropertyGroup>
-      <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
-      <Platforms>x86;x64</Platforms>
-    </PropertyGroup>
+  ```xml
+  <PropertyGroup>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+    <Platforms>x86;x64</Platforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Windows">
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Windows.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+      <Private>False</Private>
+    </Reference>
+    <PackageReference Include="Win2D.uwp" Version="1.24.0-local" />
+  </ItemGroup>
+
+  <!-- WORKAROUND: .deps.json gets not published -->
+  <PropertyGroup>
+    <DesktopBridgePublishItemsOutputGroupDependsOn>
+      $(DesktopBridgePublishItemsOutputGroupDependsOn);
+      __IncludeProjectDepsFile
+    </DesktopBridgePublishItemsOutputGroupDependsOn>
+  </PropertyGroup>
+  <Target Name="__IncludeProjectDepsFile">
     <ItemGroup>
-      <Reference Include="Windows">
-        <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Windows.winmd</HintPath>
-        <IsWinMDFile>true</IsWinMDFile>
-        <Private>False</Private>
-      </Reference>
-      <PackageReference Include="Win2D.uwp" Version="1.24.0-local" />
+      <ResolvedFileToPublish Include="$(ProjectDepsFilePath)">
+        <RelativePath>$(ProjectDepsFileName)</RelativePath>
+      </ResolvedFileToPublish>
     </ItemGroup>
+  </Target>
 	```
 - `dotnet sln add wpfapp`
 - Open the solution in VS 2019 Preview
 - Add a new Windows Application Packaging Project `wpfapp.package` with Target version `Windows 10.0.17763.0` or higher  
   *NOTE*: If you want to generate a `.msix` package (instead of `.appx`) choose `Windows 10.0.17763.0` or higher also as Target min version
+- Add a project reference `wpfapp.package` -> `wpfapp`
 - Add this to `wpfapp.package\wpfapp.package.wapproj`
   ```xml
   <ItemGroup>
@@ -94,6 +112,24 @@ The current preview package has some support for using Win2D in XAML Islands but
       <PlatformTarget>$(PlatformTarget)</PlatformTarget>
     </VCLibTargets>
   </ItemGroup>
+
+  <!-- WORKAROUND: At startup Microsoft.Graphics.Canvas.winmd is expected in the same directory as the .exe (sideloaded: AppX\XamlIslandSample.Desktop). Duplicate the .winmd item -->
+  <Target Name="__CopyWinMDToProjectDir" BeforeTargets="_CopyPackageFiles">
+    <ItemGroup>
+      <DuplicatedWinMDFiles Condition="'%(WapProjPackageFile.Extension)' == '.winmd' and '%(WapProjPackageFile.DependencyKind)' == 'Direct'" Include="%(WapProjPackageFile.Identity)">
+        <CopyToTargetPath>$([System.IO.Path]::Combine($(TargetDir), %(WapProjPackageFile.SourceProject), %(WapProjPackageFile.TargetPath)))</CopyToTargetPath>
+        <TargetPath>$([System.IO.Path]::Combine(%(WapProjPackageFile.SourceProject), %(WapProjPackageFile.TargetPath)))</TargetPath>
+      </DuplicatedWinMDFiles>
+      <AppxPackagePayload Include="@(DuplicatedWinMDFiles)" />
+      <File Include="@(DuplicatedWinMDFiles)" />
+      <DuplicatedUploadWinMDFiles Condition="'%(UploadWapProjPackageFile.Extension)' == '.winmd' and '%(UploadWapProjPackageFile.DependencyKind)' == 'Direct'" Include="%(UploadWapProjPackageFile.Identity)">
+        <CopyToTargetPath>$([System.IO.Path]::Combine($(TargetDir), %(UploadWapProjPackageFile.SourceProject), %(UploadWapProjPackageFile.TargetPath)))</CopyToTargetPath>
+        <TargetPath>$([System.IO.Path]::Combine(%(UploadWapProjPackageFile.SourceProject), %(UploadWapProjPackageFile.TargetPath)))</TargetPath>
+      </DuplicatedUploadWinMDFiles>
+      <AppxUploadPackagePayload Include="@(DuplicatedUploadWinMDFiles)" />
+      <UploadFile Include="@(DuplicatedUploadWinMDFiles)" />
+    </ItemGroup>
+  </Target>
   ```
-- Add a project reference `wpfapp.package` -> `wpfapp`
+
 

--- a/samples/XamlIslandSample/README.md
+++ b/samples/XamlIslandSample/README.md
@@ -85,7 +85,8 @@ The current preview package has some support for using Win2D in XAML Islands but
     <PackageReference Include="Win2D.uwp" Version="1.24.0-local" />
   </ItemGroup>
 
-  <!-- WORKAROUND: .deps.json gets not published -->
+  <!-- WOKAROUND: .deps.json gets not published 
+                  https://developercommunity.visualstudio.com/content/problem/462646/referencing-native-winrt-component-in-net-core-wpf.html -->
   <PropertyGroup>
     <DesktopBridgePublishItemsOutputGroupDependsOn>
       $(DesktopBridgePublishItemsOutputGroupDependsOn);
@@ -113,7 +114,9 @@ The current preview package has some support for using Win2D in XAML Islands but
     </VCLibTargets>
   </ItemGroup>
 
-  <!-- WORKAROUND: At startup Microsoft.Graphics.Canvas.winmd is expected in the same directory as the .exe (sideloaded: AppX\XamlIslandSample.Desktop). Duplicate the .winmd item -->
+  <!-- WORKAROUND: At startup Microsoft.Graphics.Canvas.winmd is expected in the same directory as the .exe 
+                   (sideloaded: AppX\XamlIslandSample.Desktop). Duplicate the .winmd item 
+                   https://developercommunity.visualstudio.com/content/problem/462646/referencing-native-winrt-component-in-net-core-wpf.html -->
   <Target Name="__CopyWinMDToProjectDir" BeforeTargets="_CopyPackageFiles">
     <ItemGroup>
       <DuplicatedWinMDFiles Condition="'%(WapProjPackageFile.Extension)' == '.winmd' and '%(WapProjPackageFile.DependencyKind)' == 'Direct'" Include="%(WapProjPackageFile.Identity)">

--- a/samples/XamlIslandSample/XamlIslandSample.Desktop/MainWindow.xaml.cs
+++ b/samples/XamlIslandSample/XamlIslandSample.Desktop/MainWindow.xaml.cs
@@ -18,11 +18,13 @@ namespace XamlIslandSample.Desktop
         public MainWindow()
         {
             InitializeComponent();
-        }
 
-        private void ButtonExit_Click(object sender, RoutedEventArgs e)
-        {
-            Application.Current.Shutdown();
+            // Test the deployment
+            // This only works when the .deps.json file is published
+            if (string.IsNullOrEmpty(AppDomain.CurrentDomain.GetData("FX_PRODUCT_VERSION") as string))
+            {
+                MessageBox.Show("No .deps.json file found.");
+            }
         }
 
         private void CanvasSwapChainPanel_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/samples/XamlIslandSample/XamlIslandSample.Desktop/XamlIslandSample.Desktop.csproj
+++ b/samples/XamlIslandSample/XamlIslandSample.Desktop/XamlIslandSample.Desktop.csproj
@@ -35,7 +35,8 @@
     </Reference>
   </ItemGroup>
 
-  <!-- WOKAROUND: .deps.json gets not published -->
+  <!-- WOKAROUND: .deps.json gets not published 
+                  https://developercommunity.visualstudio.com/content/problem/462646/referencing-native-winrt-component-in-net-core-wpf.html -->
   <PropertyGroup>
     <DesktopBridgePublishItemsOutputGroupDependsOn>
       $(DesktopBridgePublishItemsOutputGroupDependsOn);

--- a/samples/XamlIslandSample/XamlIslandSample.Desktop/XamlIslandSample.Desktop.csproj
+++ b/samples/XamlIslandSample/XamlIslandSample.Desktop/XamlIslandSample.Desktop.csproj
@@ -35,4 +35,19 @@
     </Reference>
   </ItemGroup>
 
+  <!-- WOKAROUND: .deps.json gets not published -->
+  <PropertyGroup>
+    <DesktopBridgePublishItemsOutputGroupDependsOn>
+      $(DesktopBridgePublishItemsOutputGroupDependsOn);
+      __IncludeProjectDepsFile
+    </DesktopBridgePublishItemsOutputGroupDependsOn>
+  </PropertyGroup>
+  <Target Name="__IncludeProjectDepsFile">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(ProjectDepsFilePath)">
+        <RelativePath>$(ProjectDepsFileName)</RelativePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/samples/XamlIslandSample/XamlIslandSample.Package/XamlIslandSample.Package.wapproj
+++ b/samples/XamlIslandSample/XamlIslandSample.Package/XamlIslandSample.Package.wapproj
@@ -62,7 +62,9 @@
     </ProjectReference>
   </ItemGroup>
 
-  <!-- WORKAROUND: At startup Microsoft.Graphics.Canvas.winmd is expected in the same directory as the .exe (sideloaded: AppX\XamlIslandSample.Desktop). Duplicate the .winmd item -->
+  <!-- WORKAROUND: At startup Microsoft.Graphics.Canvas.winmd is expected in the same directory as the .exe 
+                   (sideloaded: AppX\XamlIslandSample.Desktop). Duplicate the .winmd item 
+                   https://developercommunity.visualstudio.com/content/problem/462646/referencing-native-winrt-component-in-net-core-wpf.html -->
   <Target Name="__CopyWinMDToProjectDir" BeforeTargets="_CopyPackageFiles">
     <ItemGroup>
       <DuplicatedWinMDFiles Condition="'%(WapProjPackageFile.WinMDFile)' == 'true' and '%(WapProjPackageFile.DependencyKind)' == 'Direct'" Include="%(WapProjPackageFile.Identity)">

--- a/samples/XamlIslandSample/XamlIslandSample.Package/XamlIslandSample.Package.wapproj
+++ b/samples/XamlIslandSample/XamlIslandSample.Package/XamlIslandSample.Package.wapproj
@@ -61,5 +61,25 @@
       <SkipGetTargetFrameworkProperties>True</SkipGetTargetFrameworkProperties>
     </ProjectReference>
   </ItemGroup>
+
+  <!-- WORKAROUND: At startup Microsoft.Graphics.Canvas.winmd is expected in the same directory as the .exe (sideloaded: AppX\XamlIslandSample.Desktop). Duplicate the .winmd item -->
+  <Target Name="__CopyWinMDToProjectDir" BeforeTargets="_CopyPackageFiles">
+    <ItemGroup>
+      <DuplicatedWinMDFiles Condition="'%(WapProjPackageFile.WinMDFile)' == 'true' and '%(WapProjPackageFile.DependencyKind)' == 'Direct'" Include="%(WapProjPackageFile.Identity)">
+        <CopyToTargetPath>$([System.IO.Path]::Combine($(TargetDir), %(WapProjPackageFile.SourceProject), %(WapProjPackageFile.TargetPath)))</CopyToTargetPath>
+        <TargetPath>$([System.IO.Path]::Combine(%(WapProjPackageFile.SourceProject), %(WapProjPackageFile.TargetPath)))</TargetPath>
+      </DuplicatedWinMDFiles>
+      <AppxPackagePayload Include="@(DuplicatedWinMDFiles)" />
+      <File Include="@(DuplicatedWinMDFiles)" />
+
+      <DuplicatedUploadWinMDFiles Condition="'%(UploadWapProjPackageFile.WinMDFile)' == 'true' and '%(UploadWapProjPackageFile.DependencyKind)' == 'Direct'" Include="%(UploadWapProjPackageFile.Identity)">
+        <CopyToTargetPath>$([System.IO.Path]::Combine($(TargetDir), %(UploadWapProjPackageFile.SourceProject), %(UploadWapProjPackageFile.TargetPath)))</CopyToTargetPath>
+        <TargetPath>$([System.IO.Path]::Combine(%(UploadWapProjPackageFile.SourceProject), %(UploadWapProjPackageFile.TargetPath)))</TargetPath>
+      </DuplicatedUploadWinMDFiles>
+      <AppxUploadPackagePayload Include="@(DuplicatedUploadWinMDFiles)" />
+      <UploadFile Include="@(DuplicatedUploadWinMDFiles)" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 </Project>


### PR DESCRIPTION
I recognized that the .deps.json file (a .NET Core thing) is not included in the appx deployment. That leads to subtle issues (e.g. the .net runtime version information doesn't work !).
Added workarounds to sample and updated README
(Visual Studio bug: https://developercommunity.visualstudio.com/content/problem/462646/referencing-native-winrt-component-in-net-core-wpf.html)