### PR TITLE
Add support to netcoreapp3.0 projects to NuGet package

### DIFF
--- a/build/nuget/Win2D.uwp-managed.targets
+++ b/build/nuget/Win2D.uwp-managed.targets
@@ -2,6 +2,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <win2d-Platform Condition="$(RuntimeIdentifier.EndsWith('-x64'))">x64</win2d-Platform>
+    <win2d-Platform Condition="$(RuntimeIdentifier.EndsWith('-x86'))">x86</win2d-Platform>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(win2d-Platform)' == ''">
     <win2d-Platform Condition="'$(Platform)' == 'Win32'">x86</win2d-Platform>
     <win2d-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</win2d-Platform>
   </PropertyGroup>

--- a/build/nuget/Win2D.uwp-managed.targets
+++ b/build/nuget/Win2D.uwp-managed.targets
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <win2d-Platform Condition="'$(Platform)' == 'Win32'">x86</win2d-Platform>
+    <win2d-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</win2d-Platform>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Graphics.Canvas.winmd">
+      <Implementation>Microsoft.Graphics.Canvas.dll</Implementation>
+    </Reference>
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(win2d-Platform)\native\Microsoft.Graphics.Canvas.dll" />
+  </ItemGroup>
+
+  <!--
+  Don't import Win2D.common.targets here, as it will cause build failures because desktop project
+  files don't define $(TargetPlatformVersion) with the same semantics as with UWP or C++ project files.
+  -->
+
+</Project>

--- a/build/nuget/Win2D.uwp-managed.targets
+++ b/build/nuget/Win2D.uwp-managed.targets
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Graphics.Canvas.winmd">
+    <Reference Include="Microsoft.Graphics.Canvas">
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Graphics.Canvas.winmd</HintPath>
       <Implementation>Microsoft.Graphics.Canvas.dll</Implementation>
     </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(win2d-Platform)\native\Microsoft.Graphics.Canvas.dll" />

--- a/build/nuget/Win2D.uwp-managed.targets
+++ b/build/nuget/Win2D.uwp-managed.targets
@@ -9,6 +9,11 @@
   <PropertyGroup Condition="'$(win2d-Platform)' == ''">
     <win2d-Platform Condition="'$(Platform)' == 'Win32'">x86</win2d-Platform>
     <win2d-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</win2d-Platform>
+    <win2d-Platform Condition="'$(Platform)' == 'AnyCPU'"></win2d-Platform>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Win2DWarnNoPlatform Condition="'$(Win2DWarnNoPlatform)' == ''">true</Win2DWarnNoPlatform>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,8 +21,12 @@
       <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Graphics.Canvas.winmd</HintPath>
       <Implementation>Microsoft.Graphics.Canvas.dll</Implementation>
     </Reference>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(win2d-Platform)\native\Microsoft.Graphics.Canvas.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(win2d-Platform)\native\Microsoft.Graphics.Canvas.dll" Condition="'$(win2d-Platform)' != ''" />
   </ItemGroup>
+
+  <Target Name="Win2DWarnNoPlatform" BeforeTargets="BeforeBuild" Condition="'$(win2d-Platform)' == '' and '$(Win2DWarnNoPlatform)' == 'true'">
+    <Warning Text="Microsoft.Graphics.Canvas.dll could not be copied because the AnyCPU platform is being used. Please specify a specific platform to copy this file." />
+  </Target>
 
   <!--
   Don't import Win2D.common.targets here, as it will cause build failures because desktop project

--- a/build/nuget/Win2D.uwp.nuspec
+++ b/build/nuget/Win2D.uwp.nuspec
@@ -20,6 +20,7 @@
       <file target="Win2d.githash.txt"                                       src="obj\Win2d.githash.txt" />
 
       <file target="build\native\Win2D.uwp.targets"                          src="build\nuget\Win2D.uwp-native.targets" />
+      <file target="build\netcoreapp3.0\Win2D.uwp.targets"                   src="build\nuget\Win2D.uwp-managed.targets" />
       <file target="build\win10\Win2D.uwp.targets"                           src="build\nuget\Win2D.uwp-win10.targets" />
       <file target="build\Win2D.common.targets"                              src="build\nuget\Win2D.common.targets" />
 

--- a/build/nuget/Win2D.uwp.nuspec
+++ b/build/nuget/Win2D.uwp.nuspec
@@ -21,6 +21,7 @@
 
       <file target="build\native\Win2D.uwp.targets"                          src="build\nuget\Win2D.uwp-native.targets" />
       <file target="build\netcoreapp3.0\Win2D.uwp.targets"                   src="build\nuget\Win2D.uwp-managed.targets" />
+      <file target="build\net45\Win2D.uwp.targets"                           src="build\nuget\Win2D.uwp-managed.targets" />
       <file target="build\win10\Win2D.uwp.targets"                           src="build\nuget\Win2D.uwp-win10.targets" />
       <file target="build\Win2D.common.targets"                              src="build\nuget\Win2D.common.targets" />
 
@@ -29,6 +30,10 @@
 
       <file target="lib\uap10.0\Microsoft.Graphics.Canvas.winmd"             src="$bin$\UAPx86\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.winmd" />
       <file target="lib\uap10.0\Microsoft.Graphics.Canvas.xml"               src="bin\intellisense\Microsoft.Graphics.Canvas.xml" />
+      <file target="lib\netcoreapp3.0\Microsoft.Graphics.Canvas.winmd"       src="$bin$\UAPx86\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.winmd" />
+      <file target="lib\netcoreapp3.0\Microsoft.Graphics.Canvas.xml"         src="bin\intellisense\Microsoft.Graphics.Canvas.xml" />
+      <file target="lib\net45\Microsoft.Graphics.Canvas.winmd"       src="$bin$\UAPx86\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.winmd" />
+      <file target="lib\net45\Microsoft.Graphics.Canvas.xml"         src="bin\intellisense\Microsoft.Graphics.Canvas.xml" />
 
       <file target="runtimes\win10-arm\native\Microsoft.Graphics.Canvas.dll" src="$bin$\UAPARM\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.dll" />
       <file target="runtimes\win10-x64\native\Microsoft.Graphics.Canvas.dll" src="$bin$\UAPx64\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.dll" />


### PR DESCRIPTION
This will aid consuming Win2D in projects [such as this one](https://github.com/microsoft/Windows.UI.Composition-Win32-Samples/tree/master/dotnet/WinForms/AcrylicEffect), which currently requires manually unpacking the Win2D nuget package and coping a file into the bin directory, which is hard to automate using a build system (at least without checking prebuilt binary files into your repo). I can also add .NET Framework support if desired; if so, please let me know what TFM I should use. Thanks!