### PR TITLE
Fix build with Visual Studio 2019 (with tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ Studio, add the Win2D NuGet package to your project, and get started using the A
 ## Building Win2D from source
 
 ##### Requirements
-- Visual Studio 2017 with Tools for Universal Windows Apps 15.0.27428.01 and Windows SDK 17134
+- Visual Studio 2019 with Tools for Universal Windows Apps 15.0.27428.01 and Windows SDK 18362
 
 ##### Clone Repository
 - Go to 'View' -> 'Team Explorer' -> 'Local Git Repositories' -> 'Clone'
 - Add the Win2D repository URL (https://github.com/Microsoft/Win2D.git) and hit 'Clone'
 
 ##### Build NuGet Packages
-- Launch 'Developer Command Prompt for VS2017'
+- Launch 'Developer Command Prompt for VS2019'
 - Change directory to your cloned Win2D repository and run 'build'
 
 ##### Point Visual Studio at the resulting 'bin' directory

--- a/Win2D.proj
+++ b/Win2D.proj
@@ -233,7 +233,7 @@
     <_VsTest Condition="Exists('$(VS120COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS120COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
     <_VsTest Condition="Exists('$(VS140COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS140COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
     <_VsTest Condition="Exists('$(VS150COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS150COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
-    <VsTest>"$([System.IO.Path]::GetFullPath('$(_VsTest)'))"</VsTest>
+    <VsTest Condition="'$(_VsTest)' != ''">"$([System.IO.Path]::GetFullPath('$(_VsTest)'))"</VsTest>
   </PropertyGroup>
 
   <Target Name="RunTests"
@@ -242,6 +242,7 @@
           Inputs="@(TestProjects)"
           Outputs="%(TestProjects.TestAppX)">
 
+    <Error Text="vstest.console.exe not found, please specify using the VsTest property" Condition="'$(VsTest)' == ''" />
     <Message Importance="High" Text="Running tests: %(TestProjects.Filename) (%(TestProjects.Configuration)|%(TestProjects.Platform))" />
 
     <Exec Command="$(VsTest) %(TestProjects.TestBinary)%(TestProjects.TestArgs)" ContinueOnError="ErrorAndContinue" IgnoreStandardErrorWarningFormat="true" />

--- a/Win2D.proj
+++ b/Win2D.proj
@@ -233,6 +233,7 @@
     <_VsTest Condition="Exists('$(VS120COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS120COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
     <_VsTest Condition="Exists('$(VS140COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS140COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
     <_VsTest Condition="Exists('$(VS150COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS150COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
+	<_VsTest Condition="Exists('$(VS160COMNTOOLS)$(_VsTestPathUnderCommonTools)')">$(VS160COMNTOOLS)$(_VsTestPathUnderCommonTools)</_VsTest>
     <VsTest Condition="'$(_VsTest)' != ''">"$([System.IO.Path]::GetFullPath('$(_VsTest)'))"</VsTest>
   </PropertyGroup>
 
@@ -242,9 +243,14 @@
           Inputs="@(TestProjects)"
           Outputs="%(TestProjects.TestAppX)">
 
+    <PropertyGroup>
+        <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
+    </PropertyGroup>
+
     <Error Text="vstest.console.exe not found, please specify using the VsTest property" Condition="'$(VsTest)' == ''" />
     <Message Importance="High" Text="Running tests: %(TestProjects.Filename) (%(TestProjects.Configuration)|%(TestProjects.Platform))" />
 
+	<Exec Command="$(PowerShellExe) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { get-appxpackage -name E2C40EB9-8CCE-48B1-9A5C-4C8CA4999631 | remove-appxpackage } &quot;" ConsoleToMsBuild="true" ContinueOnError="ErrorAndContinue" IgnoreStandardErrorWarningFormat="true"/>
     <Exec Command="$(VsTest) %(TestProjects.TestBinary)%(TestProjects.TestArgs)" ContinueOnError="ErrorAndContinue" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 

--- a/Win2D.uap.sln
+++ b/Win2D.uap.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "winrt", "winrt", "{0F212400-0A8B-4E26-9BA8-CE7165FF8717}"
 EndProject

--- a/build.cmd
+++ b/build.cmd
@@ -2,7 +2,7 @@
 
 SETLOCAL
 
-IF "%VisualStudioVersion%" LSS "15.0" (
+IF "%VisualStudioVersion%" LSS "16.0" (
     GOTO WRONG_COMMAND_PROMPT
 )
 
@@ -35,7 +35,7 @@ GOTO END
 
 :WRONG_COMMAND_PROMPT
 
-ECHO Please run this script from a Developer Command Prompt for VS2017
+ECHO Please run this script from a Developer Command Prompt for VS2019
 ECHO.
 PAUSE
 GOTO END

--- a/build/Win2D.cpp.props
+++ b/build/Win2D.cpp.props
@@ -45,7 +45,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 

--- a/build/Win2D.cpp.props
+++ b/build/Win2D.cpp.props
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(ApplicationType)' == 'Windows Store' And '$(ApplicationTypeRevision)' == '10.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(ApplicationType)' == 'Windows Store' And '$(ApplicationTypeRevision)' == '10.0'">v142</PlatformToolset>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/Win2D.cpp.props
+++ b/build/Win2D.cpp.props
@@ -45,7 +45,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 

--- a/build/Win2D.cs.props
+++ b/build/Win2D.cs.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
   </PropertyGroup>
 </Project>

--- a/build/nuget/Win2D.common.targets
+++ b/build/nuget/Win2D.common.targets
@@ -28,7 +28,7 @@
 
   <Target Name="Win2DValidatePlatformVersion"
           BeforeTargets="ResolveAssemblyReferences"
-          Condition="'$(TargetPlatformVersion)' != '' and '$(DisableWin2DPlatformCheck)' == ''">
+          Condition="('$(TargetPlatformVersion)' != '' and '$(TargetPlatformVersion)' != '10.0') and '$(DisableWin2DPlatformCheck)' == ''">
 
     <Win2DIsPlatformTooOld ActualVersion="$(TargetPlatformVersion)" RequiredVersion="$(Win2DMinPlatformVersion)">
       <Output TaskParameter="Result" PropertyName="Win2DPlatformTooOld" />

--- a/samples/CompositionExample/CompositionExample.csproj
+++ b/samples/CompositionExample/CompositionExample.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -91,7 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/CoreWindowExample/CoreWindowExample.uap.csproj
+++ b/samples/CoreWindowExample/CoreWindowExample.uap.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -91,7 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/ExampleGallery/BackgroundTask/ExampleGallery.BackgroundTask.uap.csproj
+++ b/samples/ExampleGallery/BackgroundTask/ExampleGallery.BackgroundTask.uap.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -90,7 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/samples/ExampleGallery/Effects/ExampleGallery.Effects.csproj
+++ b/samples/ExampleGallery/Effects/ExampleGallery.Effects.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -91,7 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/ExampleGallery/ExampleGallery.uap.csproj
+++ b/samples/ExampleGallery/ExampleGallery.uap.csproj
@@ -106,7 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/SimpleSample/SimpleSample.uap.csproj
+++ b/samples/SimpleSample/SimpleSample.uap.csproj
@@ -125,7 +125,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/tools/codegen/exe/OutputEffectType.cs
+++ b/tools/codegen/exe/OutputEffectType.cs
@@ -486,7 +486,7 @@ namespace CodeGen
             }
             else
             {
-                output.WriteLine("ActivatableClassWithFactory(" + effect.ClassName + ", SimpleAgileActivationFactory<" + effect.ClassName + ">);");
+                output.WriteLine("ActivatableClassWithFactory(" + effect.ClassName + ", ::SimpleAgileActivationFactory<" + effect.ClassName + ">);");
             }
 
             output.Unindent();

--- a/winrt/lib/effects/generated/ArithmeticCompositeEffect.cpp
+++ b/winrt/lib/effects/generated/ArithmeticCompositeEffect.cpp
@@ -37,5 +37,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(ArithmeticCompositeEffect,
         { L"ClampOutput", D2D1_ARITHMETICCOMPOSITE_PROP_CLAMP_OUTPUT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(ArithmeticCompositeEffect, SimpleAgileActivationFactory<ArithmeticCompositeEffect>);
+    ActivatableClassWithFactory(ArithmeticCompositeEffect, ::SimpleAgileActivationFactory<ArithmeticCompositeEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/AtlasEffect.cpp
+++ b/winrt/lib/effects/generated/AtlasEffect.cpp
@@ -40,5 +40,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"SourceRectangle",  D2D1_ATLAS_PROP_INPUT_RECT,         GRAPHICS_EFFECT_PROPERTY_MAPPING_RECT_TO_VECTOR4 },
         { L"PaddingRectangle", D2D1_ATLAS_PROP_INPUT_PADDING_RECT, GRAPHICS_EFFECT_PROPERTY_MAPPING_RECT_TO_VECTOR4 })
 
-    ActivatableClassWithFactory(AtlasEffect, SimpleAgileActivationFactory<AtlasEffect>);
+    ActivatableClassWithFactory(AtlasEffect, ::SimpleAgileActivationFactory<AtlasEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/BlendEffect.cpp
+++ b/winrt/lib/effects/generated/BlendEffect.cpp
@@ -36,5 +36,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(BlendEffect,
         { L"Mode", D2D1_BLEND_PROP_MODE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(BlendEffect, SimpleAgileActivationFactory<BlendEffect>);
+    ActivatableClassWithFactory(BlendEffect, ::SimpleAgileActivationFactory<BlendEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/BorderEffect.cpp
+++ b/winrt/lib/effects/generated/BorderEffect.cpp
@@ -40,5 +40,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"ExtendX", D2D1_BORDER_PROP_EDGE_MODE_X, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ExtendY", D2D1_BORDER_PROP_EDGE_MODE_Y, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(BorderEffect, SimpleAgileActivationFactory<BorderEffect>);
+    ActivatableClassWithFactory(BorderEffect, ::SimpleAgileActivationFactory<BorderEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/BrightnessEffect.cpp
+++ b/winrt/lib/effects/generated/BrightnessEffect.cpp
@@ -42,5 +42,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"WhitePoint", D2D1_BRIGHTNESS_PROP_WHITE_POINT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"BlackPoint", D2D1_BRIGHTNESS_PROP_BLACK_POINT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(BrightnessEffect, SimpleAgileActivationFactory<BrightnessEffect>);
+    ActivatableClassWithFactory(BrightnessEffect, ::SimpleAgileActivationFactory<BrightnessEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/ChromaKeyEffect.cpp
+++ b/winrt/lib/effects/generated/ChromaKeyEffect.cpp
@@ -66,7 +66,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Feather",     D2D1_CHROMAKEY_PROP_FEATHER,      GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT           },
         { L"ColorHdr",    D2D1_CHROMAKEY_PROP_COLOR,        GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN          })
 
-    ActivatableClassWithFactory(ChromaKeyEffect, SimpleAgileActivationFactory<ChromaKeyEffect>);
+    ActivatableClassWithFactory(ChromaKeyEffect, ::SimpleAgileActivationFactory<ChromaKeyEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/ColorMatrixEffect.cpp
+++ b/winrt/lib/effects/generated/ColorMatrixEffect.cpp
@@ -48,5 +48,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"AlphaMode",   D2D1_COLORMATRIX_PROP_ALPHA_MODE,   GRAPHICS_EFFECT_PROPERTY_MAPPING_COLORMATRIX_ALPHA_MODE },
         { L"ClampOutput", D2D1_COLORMATRIX_PROP_CLAMP_OUTPUT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT                 })
 
-    ActivatableClassWithFactory(ColorMatrixEffect, SimpleAgileActivationFactory<ColorMatrixEffect>);
+    ActivatableClassWithFactory(ColorMatrixEffect, ::SimpleAgileActivationFactory<ColorMatrixEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/ColorSourceEffect.cpp
+++ b/winrt/lib/effects/generated/ColorSourceEffect.cpp
@@ -35,5 +35,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Color",    D2D1_FLOOD_PROP_COLOR, GRAPHICS_EFFECT_PROPERTY_MAPPING_COLOR_TO_VECTOR4 },
         { L"ColorHdr", D2D1_FLOOD_PROP_COLOR, GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN          })
 
-    ActivatableClassWithFactory(ColorSourceEffect, SimpleAgileActivationFactory<ColorSourceEffect>);
+    ActivatableClassWithFactory(ColorSourceEffect, ::SimpleAgileActivationFactory<ColorSourceEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/CompositeEffect.cpp
+++ b/winrt/lib/effects/generated/CompositeEffect.cpp
@@ -30,5 +30,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(CompositeEffect,
         { L"Mode", D2D1_COMPOSITE_PROP_MODE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(CompositeEffect, SimpleAgileActivationFactory<CompositeEffect>);
+    ActivatableClassWithFactory(CompositeEffect, ::SimpleAgileActivationFactory<CompositeEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/ContrastEffect.cpp
+++ b/winrt/lib/effects/generated/ContrastEffect.cpp
@@ -43,7 +43,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Contrast",    D2D1_CONTRAST_PROP_CONTRAST,    GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ClampSource", D2D1_CONTRAST_PROP_CLAMP_INPUT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(ContrastEffect, SimpleAgileActivationFactory<ContrastEffect>);
+    ActivatableClassWithFactory(ContrastEffect, ::SimpleAgileActivationFactory<ContrastEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/ConvolveMatrixEffect.cpp
+++ b/winrt/lib/effects/generated/ConvolveMatrixEffect.cpp
@@ -115,5 +115,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"BorderMode",        D2D1_CONVOLVEMATRIX_PROP_BORDER_MODE,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ClampOutput",       D2D1_CONVOLVEMATRIX_PROP_CLAMP_OUTPUT,       GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(ConvolveMatrixEffect, SimpleAgileActivationFactory<ConvolveMatrixEffect>);
+    ActivatableClassWithFactory(ConvolveMatrixEffect, ::SimpleAgileActivationFactory<ConvolveMatrixEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/CropEffect.cpp
+++ b/winrt/lib/effects/generated/CropEffect.cpp
@@ -40,5 +40,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"SourceRectangle", D2D1_CROP_PROP_RECT,        GRAPHICS_EFFECT_PROPERTY_MAPPING_RECT_TO_VECTOR4 },
         { L"BorderMode",      D2D1_CROP_PROP_BORDER_MODE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT          })
 
-    ActivatableClassWithFactory(CropEffect, SimpleAgileActivationFactory<CropEffect>);
+    ActivatableClassWithFactory(CropEffect, ::SimpleAgileActivationFactory<CropEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/DirectionalBlurEffect.cpp
+++ b/winrt/lib/effects/generated/DirectionalBlurEffect.cpp
@@ -57,5 +57,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Optimization", D2D1_DIRECTIONALBLUR_PROP_OPTIMIZATION,       GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"BorderMode",   D2D1_DIRECTIONALBLUR_PROP_BORDER_MODE,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             })
 
-    ActivatableClassWithFactory(DirectionalBlurEffect, SimpleAgileActivationFactory<DirectionalBlurEffect>);
+    ActivatableClassWithFactory(DirectionalBlurEffect, ::SimpleAgileActivationFactory<DirectionalBlurEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/DiscreteTransferEffect.cpp
+++ b/winrt/lib/effects/generated/DiscreteTransferEffect.cpp
@@ -92,5 +92,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"AlphaDisable", D2D1_DISCRETETRANSFER_PROP_ALPHA_DISABLE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ClampOutput",  D2D1_DISCRETETRANSFER_PROP_CLAMP_OUTPUT,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(DiscreteTransferEffect, SimpleAgileActivationFactory<DiscreteTransferEffect>);
+    ActivatableClassWithFactory(DiscreteTransferEffect, ::SimpleAgileActivationFactory<DiscreteTransferEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/DisplacementMapEffect.cpp
+++ b/winrt/lib/effects/generated/DisplacementMapEffect.cpp
@@ -52,5 +52,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"XChannelSelect", D2D1_DISPLACEMENTMAP_PROP_X_CHANNEL_SELECT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"YChannelSelect", D2D1_DISPLACEMENTMAP_PROP_Y_CHANNEL_SELECT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(DisplacementMapEffect, SimpleAgileActivationFactory<DisplacementMapEffect>);
+    ActivatableClassWithFactory(DisplacementMapEffect, ::SimpleAgileActivationFactory<DisplacementMapEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/DistantDiffuseEffect.cpp
+++ b/winrt/lib/effects/generated/DistantDiffuseEffect.cpp
@@ -90,5 +90,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"HeightMapInterpolationMode", D2D1_DISTANTDIFFUSE_PROP_SCALE_MODE,         GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"LightColorHdr",              D2D1_DISTANTDIFFUSE_PROP_COLOR,              GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN            })
 
-    ActivatableClassWithFactory(DistantDiffuseEffect, SimpleAgileActivationFactory<DistantDiffuseEffect>);
+    ActivatableClassWithFactory(DistantDiffuseEffect, ::SimpleAgileActivationFactory<DistantDiffuseEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/DistantSpecularEffect.cpp
+++ b/winrt/lib/effects/generated/DistantSpecularEffect.cpp
@@ -99,5 +99,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"HeightMapInterpolationMode", D2D1_DISTANTSPECULAR_PROP_SCALE_MODE,         GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"LightColorHdr",              D2D1_DISTANTSPECULAR_PROP_COLOR,              GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN            })
 
-    ActivatableClassWithFactory(DistantSpecularEffect, SimpleAgileActivationFactory<DistantSpecularEffect>);
+    ActivatableClassWithFactory(DistantSpecularEffect, ::SimpleAgileActivationFactory<DistantSpecularEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/DpiCompensationEffect.cpp
+++ b/winrt/lib/effects/generated/DpiCompensationEffect.cpp
@@ -48,5 +48,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"BorderMode",        D2D1_DPICOMPENSATION_PROP_BORDER_MODE,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"SourceDpi",         D2D1_DPICOMPENSATION_PROP_INPUT_DPI,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(DpiCompensationEffect, SimpleAgileActivationFactory<DpiCompensationEffect>);
+    ActivatableClassWithFactory(DpiCompensationEffect, ::SimpleAgileActivationFactory<DpiCompensationEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/EdgeDetectionEffect.cpp
+++ b/winrt/lib/effects/generated/EdgeDetectionEffect.cpp
@@ -68,7 +68,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"OverlayEdges", D2D1_EDGEDETECTION_PROP_OVERLAY_EDGES, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT                 },
         { L"AlphaMode",    D2D1_EDGEDETECTION_PROP_ALPHA_MODE,    GRAPHICS_EFFECT_PROPERTY_MAPPING_COLORMATRIX_ALPHA_MODE })
 
-    ActivatableClassWithFactory(EdgeDetectionEffect, SimpleAgileActivationFactory<EdgeDetectionEffect>);
+    ActivatableClassWithFactory(EdgeDetectionEffect, ::SimpleAgileActivationFactory<EdgeDetectionEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/EmbossEffect.cpp
+++ b/winrt/lib/effects/generated/EmbossEffect.cpp
@@ -43,7 +43,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Amount", D2D1_EMBOSS_PROP_HEIGHT,    GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"Angle",  D2D1_EMBOSS_PROP_DIRECTION, GRAPHICS_EFFECT_PROPERTY_MAPPING_RADIANS_TO_DEGREES })
 
-    ActivatableClassWithFactory(EmbossEffect, SimpleAgileActivationFactory<EmbossEffect>);
+    ActivatableClassWithFactory(EmbossEffect, ::SimpleAgileActivationFactory<EmbossEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/ExposureEffect.cpp
+++ b/winrt/lib/effects/generated/ExposureEffect.cpp
@@ -35,7 +35,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(ExposureEffect,
         { L"Exposure", D2D1_EXPOSURE_PROP_EXPOSURE_VALUE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(ExposureEffect, SimpleAgileActivationFactory<ExposureEffect>);
+    ActivatableClassWithFactory(ExposureEffect, ::SimpleAgileActivationFactory<ExposureEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/GammaTransferEffect.cpp
+++ b/winrt/lib/effects/generated/GammaTransferEffect.cpp
@@ -160,5 +160,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"AlphaDisable",   D2D1_GAMMATRANSFER_PROP_ALPHA_DISABLE,   GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ClampOutput",    D2D1_GAMMATRANSFER_PROP_CLAMP_OUTPUT,    GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(GammaTransferEffect, SimpleAgileActivationFactory<GammaTransferEffect>);
+    ActivatableClassWithFactory(GammaTransferEffect, ::SimpleAgileActivationFactory<GammaTransferEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/GaussianBlurEffect.cpp
+++ b/winrt/lib/effects/generated/GaussianBlurEffect.cpp
@@ -49,5 +49,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Optimization", D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION,       GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"BorderMode",   D2D1_GAUSSIANBLUR_PROP_BORDER_MODE,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(GaussianBlurEffect, SimpleAgileActivationFactory<GaussianBlurEffect>);
+    ActivatableClassWithFactory(GaussianBlurEffect, ::SimpleAgileActivationFactory<GaussianBlurEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/GrayscaleEffect.cpp
+++ b/winrt/lib/effects/generated/GrayscaleEffect.cpp
@@ -24,7 +24,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         Source,
         0)
 
-    ActivatableClassWithFactory(GrayscaleEffect, SimpleAgileActivationFactory<GrayscaleEffect>);
+    ActivatableClassWithFactory(GrayscaleEffect, ::SimpleAgileActivationFactory<GrayscaleEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/HighlightsAndShadowsEffect.cpp
+++ b/winrt/lib/effects/generated/HighlightsAndShadowsEffect.cpp
@@ -63,7 +63,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Clarity",        D2D1_HIGHLIGHTSANDSHADOWS_PROP_CLARITY,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"MaskBlurAmount", D2D1_HIGHLIGHTSANDSHADOWS_PROP_MASK_BLUR_RADIUS, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(HighlightsAndShadowsEffect, SimpleAgileActivationFactory<HighlightsAndShadowsEffect>);
+    ActivatableClassWithFactory(HighlightsAndShadowsEffect, ::SimpleAgileActivationFactory<HighlightsAndShadowsEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/HueRotationEffect.cpp
+++ b/winrt/lib/effects/generated/HueRotationEffect.cpp
@@ -32,5 +32,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(HueRotationEffect,
         { L"Angle", D2D1_HUEROTATION_PROP_ANGLE, GRAPHICS_EFFECT_PROPERTY_MAPPING_RADIANS_TO_DEGREES })
 
-    ActivatableClassWithFactory(HueRotationEffect, SimpleAgileActivationFactory<HueRotationEffect>);
+    ActivatableClassWithFactory(HueRotationEffect, ::SimpleAgileActivationFactory<HueRotationEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/HueToRgbEffect.cpp
+++ b/winrt/lib/effects/generated/HueToRgbEffect.cpp
@@ -34,7 +34,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(HueToRgbEffect,
         { L"SourceColorSpace", D2D1_HUETORGB_PROP_INPUT_COLOR_SPACE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(HueToRgbEffect, SimpleAgileActivationFactory<HueToRgbEffect>);
+    ActivatableClassWithFactory(HueToRgbEffect, ::SimpleAgileActivationFactory<HueToRgbEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/InvertEffect.cpp
+++ b/winrt/lib/effects/generated/InvertEffect.cpp
@@ -24,7 +24,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         Source,
         0)
 
-    ActivatableClassWithFactory(InvertEffect, SimpleAgileActivationFactory<InvertEffect>);
+    ActivatableClassWithFactory(InvertEffect, ::SimpleAgileActivationFactory<InvertEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/LinearTransferEffect.cpp
+++ b/winrt/lib/effects/generated/LinearTransferEffect.cpp
@@ -128,5 +128,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"AlphaDisable", D2D1_LINEARTRANSFER_PROP_ALPHA_DISABLE,     GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ClampOutput",  D2D1_LINEARTRANSFER_PROP_CLAMP_OUTPUT,      GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(LinearTransferEffect, SimpleAgileActivationFactory<LinearTransferEffect>);
+    ActivatableClassWithFactory(LinearTransferEffect, ::SimpleAgileActivationFactory<LinearTransferEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/LuminanceToAlphaEffect.cpp
+++ b/winrt/lib/effects/generated/LuminanceToAlphaEffect.cpp
@@ -22,5 +22,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         Source,
         0)
 
-    ActivatableClassWithFactory(LuminanceToAlphaEffect, SimpleAgileActivationFactory<LuminanceToAlphaEffect>);
+    ActivatableClassWithFactory(LuminanceToAlphaEffect, ::SimpleAgileActivationFactory<LuminanceToAlphaEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/MorphologyEffect.cpp
+++ b/winrt/lib/effects/generated/MorphologyEffect.cpp
@@ -50,5 +50,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Width",  D2D1_MORPHOLOGY_PROP_WIDTH,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"Height", D2D1_MORPHOLOGY_PROP_HEIGHT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(MorphologyEffect, SimpleAgileActivationFactory<MorphologyEffect>);
+    ActivatableClassWithFactory(MorphologyEffect, ::SimpleAgileActivationFactory<MorphologyEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/OpacityMetadataEffect.cpp
+++ b/winrt/lib/effects/generated/OpacityMetadataEffect.cpp
@@ -32,5 +32,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(OpacityMetadataEffect,
         { L"OpaqueRectangle", D2D1_OPACITYMETADATA_PROP_INPUT_OPAQUE_RECT, GRAPHICS_EFFECT_PROPERTY_MAPPING_RECT_TO_VECTOR4 })
 
-    ActivatableClassWithFactory(OpacityMetadataEffect, SimpleAgileActivationFactory<OpacityMetadataEffect>);
+    ActivatableClassWithFactory(OpacityMetadataEffect, ::SimpleAgileActivationFactory<OpacityMetadataEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/PointDiffuseEffect.cpp
+++ b/winrt/lib/effects/generated/PointDiffuseEffect.cpp
@@ -82,5 +82,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"HeightMapInterpolationMode", D2D1_POINTDIFFUSE_PROP_SCALE_MODE,         GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT           },
         { L"LightColorHdr",              D2D1_POINTDIFFUSE_PROP_COLOR,              GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN          })
 
-    ActivatableClassWithFactory(PointDiffuseEffect, SimpleAgileActivationFactory<PointDiffuseEffect>);
+    ActivatableClassWithFactory(PointDiffuseEffect, ::SimpleAgileActivationFactory<PointDiffuseEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/PointSpecularEffect.cpp
+++ b/winrt/lib/effects/generated/PointSpecularEffect.cpp
@@ -91,5 +91,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"HeightMapInterpolationMode", D2D1_POINTSPECULAR_PROP_SCALE_MODE,         GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT           },
         { L"LightColorHdr",              D2D1_POINTSPECULAR_PROP_COLOR,              GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN          })
 
-    ActivatableClassWithFactory(PointSpecularEffect, SimpleAgileActivationFactory<PointSpecularEffect>);
+    ActivatableClassWithFactory(PointSpecularEffect, ::SimpleAgileActivationFactory<PointSpecularEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/PosterizeEffect.cpp
+++ b/winrt/lib/effects/generated/PosterizeEffect.cpp
@@ -53,7 +53,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"GreenValueCount", D2D1_POSTERIZE_PROP_GREEN_VALUE_COUNT, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"BlueValueCount",  D2D1_POSTERIZE_PROP_BLUE_VALUE_COUNT,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(PosterizeEffect, SimpleAgileActivationFactory<PosterizeEffect>);
+    ActivatableClassWithFactory(PosterizeEffect, ::SimpleAgileActivationFactory<PosterizeEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/PremultiplyEffect.cpp
+++ b/winrt/lib/effects/generated/PremultiplyEffect.cpp
@@ -22,5 +22,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         Source,
         0)
 
-    ActivatableClassWithFactory(PremultiplyEffect, SimpleAgileActivationFactory<PremultiplyEffect>);
+    ActivatableClassWithFactory(PremultiplyEffect, ::SimpleAgileActivationFactory<PremultiplyEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/RgbToHueEffect.cpp
+++ b/winrt/lib/effects/generated/RgbToHueEffect.cpp
@@ -34,7 +34,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(RgbToHueEffect,
         { L"OutputColorSpace", D2D1_RGBTOHUE_PROP_OUTPUT_COLOR_SPACE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(RgbToHueEffect, SimpleAgileActivationFactory<RgbToHueEffect>);
+    ActivatableClassWithFactory(RgbToHueEffect, ::SimpleAgileActivationFactory<RgbToHueEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/SaturationEffect.cpp
+++ b/winrt/lib/effects/generated/SaturationEffect.cpp
@@ -33,5 +33,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(SaturationEffect,
         { L"Saturation", D2D1_SATURATION_PROP_SATURATION, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(SaturationEffect, SimpleAgileActivationFactory<SaturationEffect>);
+    ActivatableClassWithFactory(SaturationEffect, ::SimpleAgileActivationFactory<SaturationEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/ScaleEffect.cpp
+++ b/winrt/lib/effects/generated/ScaleEffect.cpp
@@ -66,5 +66,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"BorderMode",        D2D1_SCALE_PROP_BORDER_MODE,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"Sharpness",         D2D1_SCALE_PROP_SHARPNESS,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(ScaleEffect, SimpleAgileActivationFactory<ScaleEffect>);
+    ActivatableClassWithFactory(ScaleEffect, ::SimpleAgileActivationFactory<ScaleEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/SepiaEffect.cpp
+++ b/winrt/lib/effects/generated/SepiaEffect.cpp
@@ -43,7 +43,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Intensity", D2D1_SEPIA_PROP_INTENSITY,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT                 },
         { L"AlphaMode", D2D1_SEPIA_PROP_ALPHA_MODE, GRAPHICS_EFFECT_PROPERTY_MAPPING_COLORMATRIX_ALPHA_MODE })
 
-    ActivatableClassWithFactory(SepiaEffect, SimpleAgileActivationFactory<SepiaEffect>);
+    ActivatableClassWithFactory(SepiaEffect, ::SimpleAgileActivationFactory<SepiaEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/ShadowEffect.cpp
+++ b/winrt/lib/effects/generated/ShadowEffect.cpp
@@ -56,5 +56,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Optimization",   D2D1_SHADOW_PROP_OPTIMIZATION,            GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT           },
         { L"ShadowColorHdr", D2D1_SHADOW_PROP_COLOR,                   GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN          })
 
-    ActivatableClassWithFactory(ShadowEffect, SimpleAgileActivationFactory<ShadowEffect>);
+    ActivatableClassWithFactory(ShadowEffect, ::SimpleAgileActivationFactory<ShadowEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/SharpenEffect.cpp
+++ b/winrt/lib/effects/generated/SharpenEffect.cpp
@@ -44,7 +44,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Amount",    D2D1_SHARPEN_PROP_SHARPNESS, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"Threshold", D2D1_SHARPEN_PROP_THRESHOLD, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(SharpenEffect, SimpleAgileActivationFactory<SharpenEffect>);
+    ActivatableClassWithFactory(SharpenEffect, ::SimpleAgileActivationFactory<SharpenEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/SpotDiffuseEffect.cpp
+++ b/winrt/lib/effects/generated/SpotDiffuseEffect.cpp
@@ -107,5 +107,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"HeightMapInterpolationMode", D2D1_SPOTDIFFUSE_PROP_SCALE_MODE,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"LightColorHdr",              D2D1_SPOTDIFFUSE_PROP_COLOR,               GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN            })
 
-    ActivatableClassWithFactory(SpotDiffuseEffect, SimpleAgileActivationFactory<SpotDiffuseEffect>);
+    ActivatableClassWithFactory(SpotDiffuseEffect, ::SimpleAgileActivationFactory<SpotDiffuseEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/SpotSpecularEffect.cpp
+++ b/winrt/lib/effects/generated/SpotSpecularEffect.cpp
@@ -116,5 +116,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"HeightMapInterpolationMode", D2D1_SPOTSPECULAR_PROP_SCALE_MODE,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"LightColorHdr",              D2D1_SPOTSPECULAR_PROP_COLOR,               GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN            })
 
-    ActivatableClassWithFactory(SpotSpecularEffect, SimpleAgileActivationFactory<SpotSpecularEffect>);
+    ActivatableClassWithFactory(SpotSpecularEffect, ::SimpleAgileActivationFactory<SpotSpecularEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/StraightenEffect.cpp
+++ b/winrt/lib/effects/generated/StraightenEffect.cpp
@@ -51,7 +51,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"MaintainSize",      D2D1_STRAIGHTEN_PROP_MAINTAIN_SIZE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             },
         { L"InterpolationMode", D2D1_STRAIGHTEN_PROP_SCALE_MODE,    GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT             })
 
-    ActivatableClassWithFactory(StraightenEffect, SimpleAgileActivationFactory<StraightenEffect>);
+    ActivatableClassWithFactory(StraightenEffect, ::SimpleAgileActivationFactory<StraightenEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/TableTransfer3DEffect.cpp
+++ b/winrt/lib/effects/generated/TableTransfer3DEffect.cpp
@@ -42,7 +42,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Table",     D2D1_LOOKUPTABLE3D_PROP_LUT,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT                 },
         { L"AlphaMode", D2D1_LOOKUPTABLE3D_PROP_ALPHA_MODE, GRAPHICS_EFFECT_PROPERTY_MAPPING_COLORMATRIX_ALPHA_MODE })
 
-    ActivatableClassWithFactory(TableTransfer3DEffect, SimpleAgileActivationFactory<TableTransfer3DEffect>);
+    ActivatableClassWithFactory(TableTransfer3DEffect, ::SimpleAgileActivationFactory<TableTransfer3DEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/TableTransferEffect.cpp
+++ b/winrt/lib/effects/generated/TableTransferEffect.cpp
@@ -92,5 +92,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"AlphaDisable", D2D1_TABLETRANSFER_PROP_ALPHA_DISABLE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"ClampOutput",  D2D1_TABLETRANSFER_PROP_CLAMP_OUTPUT,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(TableTransferEffect, SimpleAgileActivationFactory<TableTransferEffect>);
+    ActivatableClassWithFactory(TableTransferEffect, ::SimpleAgileActivationFactory<TableTransferEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/TemperatureAndTintEffect.cpp
+++ b/winrt/lib/effects/generated/TemperatureAndTintEffect.cpp
@@ -44,7 +44,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Temperature", D2D1_TEMPERATUREANDTINT_PROP_TEMPERATURE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"Tint",        D2D1_TEMPERATUREANDTINT_PROP_TINT,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(TemperatureAndTintEffect, SimpleAgileActivationFactory<TemperatureAndTintEffect>);
+    ActivatableClassWithFactory(TemperatureAndTintEffect, ::SimpleAgileActivationFactory<TemperatureAndTintEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/TileEffect.cpp
+++ b/winrt/lib/effects/generated/TileEffect.cpp
@@ -32,5 +32,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     IMPLEMENT_EFFECT_PROPERTY_MAPPING(TileEffect,
         { L"SourceRectangle", D2D1_TILE_PROP_RECT, GRAPHICS_EFFECT_PROPERTY_MAPPING_RECT_TO_VECTOR4 })
 
-    ActivatableClassWithFactory(TileEffect, SimpleAgileActivationFactory<TileEffect>);
+    ActivatableClassWithFactory(TileEffect, ::SimpleAgileActivationFactory<TileEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/Transform2DEffect.cpp
+++ b/winrt/lib/effects/generated/Transform2DEffect.cpp
@@ -57,5 +57,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"TransformMatrix",   D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX,   GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"Sharpness",         D2D1_2DAFFINETRANSFORM_PROP_SHARPNESS,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(Transform2DEffect, SimpleAgileActivationFactory<Transform2DEffect>);
+    ActivatableClassWithFactory(Transform2DEffect, ::SimpleAgileActivationFactory<Transform2DEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/Transform3DEffect.cpp
+++ b/winrt/lib/effects/generated/Transform3DEffect.cpp
@@ -49,5 +49,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"BorderMode",        D2D1_3DTRANSFORM_PROP_BORDER_MODE,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"TransformMatrix",   D2D1_3DTRANSFORM_PROP_TRANSFORM_MATRIX,   GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(Transform3DEffect, SimpleAgileActivationFactory<Transform3DEffect>);
+    ActivatableClassWithFactory(Transform3DEffect, ::SimpleAgileActivationFactory<Transform3DEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/TurbulenceEffect.cpp
+++ b/winrt/lib/effects/generated/TurbulenceEffect.cpp
@@ -80,5 +80,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Noise",     D2D1_TURBULENCE_PROP_NOISE,          GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
         { L"Tileable",  D2D1_TURBULENCE_PROP_STITCHABLE,     GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
 
-    ActivatableClassWithFactory(TurbulenceEffect, SimpleAgileActivationFactory<TurbulenceEffect>);
+    ActivatableClassWithFactory(TurbulenceEffect, ::SimpleAgileActivationFactory<TurbulenceEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/UnPremultiplyEffect.cpp
+++ b/winrt/lib/effects/generated/UnPremultiplyEffect.cpp
@@ -22,5 +22,5 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         Source,
         0)
 
-    ActivatableClassWithFactory(UnPremultiplyEffect, SimpleAgileActivationFactory<UnPremultiplyEffect>);
+    ActivatableClassWithFactory(UnPremultiplyEffect, ::SimpleAgileActivationFactory<UnPremultiplyEffect>);
 }}}}}

--- a/winrt/lib/effects/generated/VignetteEffect.cpp
+++ b/winrt/lib/effects/generated/VignetteEffect.cpp
@@ -59,7 +59,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         { L"Curve",    D2D1_VIGNETTE_PROP_STRENGTH,        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT           },
         { L"ColorHdr", D2D1_VIGNETTE_PROP_COLOR,           GRAPHICS_EFFECT_PROPERTY_MAPPING_UNKNOWN          })
 
-    ActivatableClassWithFactory(VignetteEffect, SimpleAgileActivationFactory<VignetteEffect>);
+    ActivatableClassWithFactory(VignetteEffect, ::SimpleAgileActivationFactory<VignetteEffect>);
 }}}}}
 
 #endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/winrt.lib.uap.vcxproj
+++ b/winrt/lib/winrt.lib.uap.vcxproj
@@ -50,7 +50,7 @@
     <!-- Reference paths differ depending on locally installed vs. NuGet SDK -->
     <ItemGroup Condition="'$(UseNuGetSDK)' == ''">
       <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\3.0.0.0" />
-      <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\Windows.Foundation.UniversalApiContract\6.0.0.0" />
+      <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\Windows.Foundation.UniversalApiContract\8.0.0.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(UseNuGetSDK)' != ''">
       <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\3.0.0.0" />

--- a/winrt/test.external/winrt.test.external.uap.vcxproj
+++ b/winrt/test.external/winrt.test.external.uap.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
-    <UnitTestPlatformVersion  Condition="'$(UnitTestPlatformVersion)' == ''">15.0</UnitTestPlatformVersion>
+    <UnitTestPlatformVersion  Condition="'$(UnitTestPlatformVersion)' == ''">16.0</UnitTestPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>

--- a/winrt/test.internal/mocks/MockD2DFactory.h
+++ b/winrt/test.internal/mocks/MockD2DFactory.h
@@ -6,6 +6,8 @@
 
 namespace canvas
 {
+#pragma warning(push)
+#pragma warning(disable: 4996) // GetDesktopDpi() is deprecated; don't let that break the build
     class MockD2DFactory : public RuntimeClass <
         RuntimeClassFlags<ClassicCom>,
         ChainInterfaces < ID2D1Factory2, ID2D1Factory1, ID2D1Factory >, ID2D1Multithread >
@@ -275,6 +277,7 @@ namespace canvas
         int GetEnterCount() const { return m_enterCount; }
         int GetLeaveCount() const { return m_leaveCount; }
     };
+#pragma warning(pop)
 
 
     inline ComPtr<ID2D1Factory2> MakeMockD2DFactory()

--- a/winrt/test.internal/utils/Helpers.h
+++ b/winrt/test.internal/utils/Helpers.h
@@ -671,6 +671,7 @@ namespace Microsoft
                 END_ENUM(SamplerCoordinateMapping);
             }
 
+#ifndef MS_CPP_UNITTESTFRAMEWORK_ASSERT // This overload is also defined there.
             template<>
             inline std::wstring ToString<__int64>(__int64 const& value)
             {
@@ -683,6 +684,7 @@ namespace Microsoft
 
                 return buf;
             }
+#endif
 
             ENUM_TO_STRING(DWRITE_FLOW_DIRECTION)
             {

--- a/winrt/test.internal/winrt.test.internal.uap.vcxproj
+++ b/winrt/test.internal/winrt.test.internal.uap.vcxproj
@@ -12,7 +12,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v141</PlatformToolset>
     <TargetName>winrt.test.internal.uap</TargetName>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>

--- a/winrt/test.internal/winrt.test.internal.uap.vcxproj
+++ b/winrt/test.internal/winrt.test.internal.uap.vcxproj
@@ -12,6 +12,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
   <PropertyGroup Label="Configuration">
+    <PlatformToolset>v142</PlatformToolset>
     <TargetName>winrt.test.internal.uap</TargetName>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>

--- a/winrt/test.internal/xaml/BaseControlUnitTests.cpp
+++ b/winrt/test.internal/xaml/BaseControlUnitTests.cpp
@@ -153,7 +153,7 @@ namespace
     };
 }
 
-using Internal::AggregateType;
+using ::ABI::Windows::Foundation::Internal::AggregateType;
 
 template<>
 struct ITypedEventHandler<IAnyControlInterface*, CanvasCreateResourcesEventArgs*> 

--- a/winrt/test.internal/xaml/RecreatableDeviceManagerTests.cpp
+++ b/winrt/test.internal/xaml/RecreatableDeviceManagerTests.cpp
@@ -8,7 +8,7 @@
 
 #include "mocks/MockCanvasDeviceActivationFactory.h"
 
-using Internal::AggregateType;
+using ::ABI::Windows::Foundation::Internal::AggregateType;
 
 template<>
 struct ITypedEventHandler<IInspectable*, CanvasCreateResourcesEventArgs*> 

--- a/winrt/test.managed/winrt.test.managed.uap.csproj
+++ b/winrt/test.managed/winrt.test.managed.uap.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -14,18 +14,12 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">14.0</UnitTestPlatformVersion>
+    <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">16.0</UnitTestPlatformVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <Import Project="..\..\build\Win2D.cs.props" />
-  <PropertyGroup>
-    <!--
-      Workaround https://github.com/Microsoft/vstest/issues/1535 by undoing the 
-      Win2D.common.props customization that tries to gather all obj folders in one place.
-    -->
-    <IntermediateOutputPath>obj</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>obj</BaseIntermediateOutputPath>
-  </PropertyGroup>
   <PropertyGroup>
     <PackageCertificateKeyFile>$(AssetDir)TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
@@ -119,9 +113,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
     <ApplicationDefinition Include="UnitTestApp.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -157,14 +148,17 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>16.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.8</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.2.0</Version>
+      <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>1.2.0</Version>
+      <Version>2.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/winrt/test.nativecomponent/ShaderCompiler.cpp
+++ b/winrt/test.nativecomponent/ShaderCompiler.cpp
@@ -13,10 +13,13 @@ namespace NativeComponent
     public:
         static Platform::Array<byte>^ CompileShader(Platform::String^ shaderCode, Platform::String^ targetProfile, Platform::String^ entryPoint)
         {
-            // Convert Unicode -> ASCII (sloppily, just casting wchar_t to char, but this is good enough for unit tests).
-            std::string asciiShader(shaderCode->Begin(), shaderCode->End());
-            std::string asciiProfile(targetProfile->Begin(), targetProfile->End());
-            std::string asciiEntryPoint(entryPoint->Begin(), entryPoint->End());
+            // Convert Unicode -> ASCII
+            std::string asciiShader(shaderCode->Length(), ' ');
+            std::transform(shaderCode->Begin(), shaderCode->End(), asciiShader.begin(), [](wchar_t c) { return static_cast<char>(c); });
+            std::string asciiProfile(targetProfile->Length(), ' ');
+            std::transform(targetProfile->Begin(), targetProfile->End(), asciiProfile.begin(), [](wchar_t c) { return static_cast<char>(c); });
+            std::string asciiEntryPoint(entryPoint->Length(), ' ');
+            std::transform(entryPoint->Begin(), entryPoint->End(), asciiEntryPoint.begin(), [](wchar_t c) { return static_cast<char>(c); });
 
             ComPtr<ID3DBlob> result;
             ComPtr<ID3DBlob> errors;


### PR DESCRIPTION
I reused #711 and fixed the test execution.
It now builds fine and run all the tests on all the architectures.