### PR TITLE
Fix device context pool deadlock scenario

### DIFF
--- a/winrt/lib/drawing/DeviceContextPool.cpp
+++ b/winrt/lib/drawing/DeviceContextPool.cpp
@@ -20,25 +20,27 @@ DeviceContextPool::DeviceContextPool(ID2D1Device1* d2dDevice)
 
 DeviceContextLease DeviceContextPool::TakeLease()
 {
-    Lock lock(m_mutex);
+    ID2D1Device1* localDevice;
+    {
+        Lock lock(m_mutex);
 
-    if (!m_d2dDevice)
+        if (!m_deviceContexts.empty())
+        {
+            DeviceContextLease newLease(this, std::move(m_deviceContexts.back()));
+            m_deviceContexts.pop_back();
+            return newLease;
+        }
+        localDevice = m_d2dDevice;
+    }
+    //Release lock before creating the device context to avoid potential deadlock scenarios
+    if (!localDevice)
         ThrowHR(RO_E_CLOSED);
-    
-    if (m_deviceContexts.empty())
-    {
-        ComPtr<ID2D1DeviceContext1> deviceContext;
-        ThrowIfFailed(m_d2dDevice->CreateDeviceContext(
-            D2D1_DEVICE_CONTEXT_OPTIONS_NONE,
-            &deviceContext));
-        return DeviceContextLease(this, std::move(deviceContext));
-    }
-    else
-    {
-        DeviceContextLease newLease(this, std::move(m_deviceContexts.back()));
-        m_deviceContexts.pop_back();
-        return newLease;
-    }
+
+    ComPtr<ID2D1DeviceContext1> deviceContext;
+    ThrowIfFailed(localDevice->CreateDeviceContext(
+        D2D1_DEVICE_CONTEXT_OPTIONS_NONE,
+        &deviceContext));
+    return DeviceContextLease(this, std::move(deviceContext));
 }
 
 


### PR DESCRIPTION
Fix a deadlock scenario that can occur in `DeviceContextPool::TakeLease` which is used in various places including `ICanvasImage.GetBounds()`. This fixes one of the issues identified in <https://github.com/microsoft/Win2D/issues/748>.