### PR TITLE
First attempt to fix deadlock in GetOrCreate

### DIFF
--- a/winrt/lib/utils/ResourceManager.h
+++ b/winrt/lib/utils/ResourceManager.h
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 #pragma once
+#include <unordered_set>
 
 namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
 {
@@ -26,8 +27,8 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     {
     public:
         // Used by ResourceWrapper to maintain its state in the interop mapping table.
-        static void Add(IUnknown* resource, IInspectable* wrapper);
-        static void Remove(IUnknown* resource);
+        static void Add(IUnknown* resource, IInspectable* wrapper, IUnknown * wrapperIdentity);
+        static void Remove(IUnknown* resource, IUnknown* wrapperIdentity);
 
 
         // Used internally, and exposed to apps via CanvasDeviceFactory::GetOrCreate and Microsoft.Graphics.Canvas.native.h.
@@ -157,6 +158,10 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         // Native resource -> WinRT wrapper map, shared by all active resources.
         static std::unordered_map<IUnknown*, WeakRef> m_resources;
         static std::recursive_mutex m_mutex;
+
+        //Used temporarily by GetOrCreate in conjunction with Add/Remove to prevent duplicate wrapped resources without having to lock.
+        static std::unordered_multiset<IUnknown*> m_wrappingResources;
+        static std::unordered_set<IUnknown*> m_creatingWrappers;
 
         // Table of try-create functions, one per type.
         static std::vector<TryCreateFunction> tryCreateFunctions;

--- a/winrt/lib/utils/ResourceWrapper.h
+++ b/winrt/lib/utils/ResourceWrapper.h
@@ -29,6 +29,8 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                             private LifespanTracker<TWrapper>
     {
         ClosablePtr<TResource> m_resource;
+        //Store the identity of the wrapper so we can safely use it in the destructor (ReleaseResource).
+        IUnknown* m_wrapperIdentity;
 
     protected:
         ResourceWrapper(TResource* resource)
@@ -40,7 +42,8 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         {
             if (resource)
             {
-                ResourceManager::Add(resource, outerInspectable);
+                m_wrapperIdentity = AsUnknown(outerInspectable).Get();
+                ResourceManager::Add(resource, outerInspectable, m_wrapperIdentity);
             }
         }
 
@@ -55,7 +58,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             {
                 auto resource = m_resource.Close();
 
-                ResourceManager::Remove(resource.Get());
+                ResourceManager::Remove(resource.Get(), m_wrapperIdentity);
             }
         }
 
@@ -67,7 +70,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             {
                 m_resource = resource;
 
-                ResourceManager::Add(resource, GetOuterInspectable());
+                ResourceManager::Add(resource, GetOuterInspectable(), m_wrapperIdentity);
             }
         }
 


### PR DESCRIPTION
This is an attempt to fix issue <https://github.com/microsoft/Win2D/issues/663>. I have tried to do it in such a way as to improve concurrency by locking for less of the time rather than more. The basic idea is quite simple, although it ended up being slightly more complicated than I would have liked.

The basic idea is that if two threads happen to want to create a wrapper around the same resource at the same time, which seems very unlikely, then let them do the same work in parallel, but then only return one of the created wrappers and discard the other. This allows us to release the lock for the construction of the wrapper.