### PR TITLE
Add HDR tone map and white level adjustment effects

### DIFF
--- a/build/Win2D.cpp.props
+++ b/build/Win2D.cpp.props
@@ -64,7 +64,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalOptions>/DNTDDI_VERSION=0x0A000003 /Qspectre %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/DNTDDI_VERSION=0x0A000006 /Qspectre %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   

--- a/tools/codegen/exe/OutputEffectType.cs
+++ b/tools/codegen/exe/OutputEffectType.cs
@@ -236,11 +236,7 @@ namespace CodeGen
                     output.WriteLine(customIdl.Trim());
                 }
 
-                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck))
-                {
-                    output.WriteLine("HRESULT IsSupported([in] Microsoft.Graphics.Canvas.CanvasDevice* device, [out, retval] boolean* result);");
-                }
-                else if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
+                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
                 {
                     output.WriteLine("[propget] HRESULT IsSupported([out, retval] boolean* value);");
                 }
@@ -361,10 +357,7 @@ namespace CodeGen
                     output.WriteLine(customDecl.Trim());
                 }
 
-                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck)) {
-                    output.WriteLine("IFACEMETHOD(IsSupported)(ICanvasDevice* device, boolean* result) override;");
-                }
-                else if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
+                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
                 {
                     output.WriteLine("IFACEMETHOD(get_IsSupported)(boolean* value) override;");
                 }
@@ -407,7 +400,11 @@ namespace CodeGen
 
             if (effect.Overrides != null && !string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
             {
-                output.WriteLine("if (!SharedDeviceState::GetInstance()->Is" + effect.Overrides.IsSupportedCheck + "Supported())");
+                if (effect.Overrides.IsSupportedCheck == "Registered") {
+                    output.WriteLine("if (!SharedDeviceState::GetInstance()->IsEffectRegistered(" + effect.ClassName + "::EffectId(), true))");
+                } else {
+                    output.WriteLine("if (!SharedDeviceState::GetInstance()->Is" + effect.Overrides.IsSupportedCheck + "Supported())");
+                }
                 output.Indent();
                 output.WriteLine("ThrowHR(E_NOTIMPL, Strings::NotSupportedOnThisVersionOfWindows);");
                 output.Unindent();
@@ -472,23 +469,7 @@ namespace CodeGen
                 output.WriteLine("}");
                 output.WriteLine();
 
-                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck)) {
-                    output.WriteLine("IFACEMETHODIMP " + effect.ClassName + "Factory::IsSupported(ICanvasDevice* device, boolean* result)");
-                    output.WriteLine("{");
-                    output.Indent();
-                    output.WriteLine("return ExceptionBoundary([&]");
-                    output.WriteLine("{");
-                    output.Indent();
-                    output.WriteLine("CheckInPointer(device);");
-                    output.WriteLine("CheckInPointer(result);");
-                    output.WriteLine("*result = SharedDeviceState::GetInstance()->IsEffectSupportedWithAnyDevice(device, " + effect.ClassName + "::EffectId(), L\"" + effect.Overrides.IsSupportedWithAnyDeviceCheck + "\");");
-                    output.Unindent();
-                    output.WriteLine("});");
-                    output.Unindent();
-                    output.WriteLine("}");
-                    output.WriteLine();
-                }
-                else if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
+                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
                 {
                     output.WriteLine("IFACEMETHODIMP " + effect.ClassName + "Factory::get_IsSupported(_Out_ boolean* result)");
                     output.WriteLine("{");
@@ -497,7 +478,11 @@ namespace CodeGen
                     output.WriteLine("{");
                     output.Indent();
                     output.WriteLine("CheckInPointer(result);");
-                    output.WriteLine("*result = SharedDeviceState::GetInstance()->Is" + effect.Overrides.IsSupportedCheck + "Supported();");
+                    if (effect.Overrides.IsSupportedCheck == "Registered") {
+                        output.WriteLine("*result = SharedDeviceState::GetInstance()->IsEffectRegistered(" + effect.ClassName + "::EffectId(), true);");
+                    } else {
+                        output.WriteLine("*result = SharedDeviceState::GetInstance()->Is" + effect.Overrides.IsSupportedCheck + "Supported();");
+                    }
                     output.Unindent();
                     output.WriteLine("});");
                     output.Unindent();
@@ -537,7 +522,7 @@ namespace CodeGen
 
             return effect.Overrides.CustomStaticMethodIdl.Count > 0 ||
                    effect.Overrides.CustomStaticMethodDecl.Count > 0 ||
-                   !string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck) || !string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck);
+                   !string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck);
         }
 
         private static void WritePropertyInitialization(Formatter output, Effects.Property property)

--- a/tools/codegen/exe/OutputEffectType.cs
+++ b/tools/codegen/exe/OutputEffectType.cs
@@ -236,7 +236,7 @@ namespace CodeGen
                     output.WriteLine(customIdl.Trim());
                 }
 
-                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedOnAnyDeviceCheck))
+                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck))
                 {
                     output.WriteLine("HRESULT IsSupported([in] Microsoft.Graphics.Canvas.CanvasDevice* device, [out, retval] boolean* result);");
                 }
@@ -361,7 +361,7 @@ namespace CodeGen
                     output.WriteLine(customDecl.Trim());
                 }
 
-                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedOnAnyDeviceCheck)) {
+                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck)) {
                     output.WriteLine("IFACEMETHOD(IsSupported)(ICanvasDevice* device, boolean* result) override;");
                 }
                 else if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck))
@@ -472,7 +472,7 @@ namespace CodeGen
                 output.WriteLine("}");
                 output.WriteLine();
 
-                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedOnAnyDeviceCheck)) {
+                if (!string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck)) {
                     output.WriteLine("IFACEMETHODIMP " + effect.ClassName + "Factory::IsSupported(ICanvasDevice* device, boolean* result)");
                     output.WriteLine("{");
                     output.Indent();
@@ -481,7 +481,7 @@ namespace CodeGen
                     output.Indent();
                     output.WriteLine("CheckInPointer(device);");
                     output.WriteLine("CheckInPointer(result);");
-                    output.WriteLine("*result = SharedDeviceState::GetInstance()->IsEffectSupportedOnAnyDevice(device, " + effect.ClassName + "::EffectId(), L\"" + effect.Overrides.IsSupportedOnAnyDeviceCheck + "\");");
+                    output.WriteLine("*result = SharedDeviceState::GetInstance()->IsEffectSupportedWithAnyDevice(device, " + effect.ClassName + "::EffectId(), L\"" + effect.Overrides.IsSupportedWithAnyDeviceCheck + "\");");
                     output.Unindent();
                     output.WriteLine("});");
                     output.Unindent();
@@ -537,7 +537,7 @@ namespace CodeGen
 
             return effect.Overrides.CustomStaticMethodIdl.Count > 0 ||
                    effect.Overrides.CustomStaticMethodDecl.Count > 0 ||
-                   !string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck) || !string.IsNullOrEmpty(effect.Overrides.IsSupportedOnAnyDeviceCheck);
+                   !string.IsNullOrEmpty(effect.Overrides.IsSupportedCheck) || !string.IsNullOrEmpty(effect.Overrides.IsSupportedWithAnyDeviceCheck);
         }
 
         private static void WritePropertyInitialization(Formatter output, Effects.Property property)

--- a/tools/codegen/exe/Settings.cs
+++ b/tools/codegen/exe/Settings.cs
@@ -130,16 +130,9 @@ namespace CodeGen
                 [XmlAttributeAttribute]
                 public string WinVer;
 
+                //If set to "Registered", this will checck if the effect is registered using its class ID.
                 [XmlAttributeAttribute]
                 public string IsSupportedCheck;
-
-                /** 
-                 * A non-empty value means that an IsSupported function should be added to the effect which takes a device as a parameter, but it can be any
-                 * device as the check is only OS-version dependent. The value is used as a key to cache the result so can be shared with other effect supported checks.
-                 * By convention it is of the format Win10_17763.
-                */
-                [XmlAttributeAttribute]
-                public string IsSupportedWithAnyDeviceCheck;
 
                 [XmlElement("Input")]
                 public List<EffectProperty> Inputs { get; set; }

--- a/tools/codegen/exe/Settings.cs
+++ b/tools/codegen/exe/Settings.cs
@@ -139,7 +139,7 @@ namespace CodeGen
                  * By convention it is of the format Win10_17763.
                 */
                 [XmlAttributeAttribute]
-                public string IsSupportedOnAnyDeviceCheck;
+                public string IsSupportedWithAnyDeviceCheck;
 
                 [XmlElement("Input")]
                 public List<EffectProperty> Inputs { get; set; }

--- a/tools/codegen/exe/Settings.cs
+++ b/tools/codegen/exe/Settings.cs
@@ -133,6 +133,14 @@ namespace CodeGen
                 [XmlAttributeAttribute]
                 public string IsSupportedCheck;
 
+                /** 
+                 * A non-empty value means that an IsSupported function should be added to the effect which takes a device as a parameter, but it can be any
+                 * device as the check is only OS-version dependent. The value is used as a key to cache the result so can be shared with other effect supported checks.
+                 * By convention it is of the format Win10_17763.
+                */
+                [XmlAttributeAttribute]
+                public string IsSupportedOnAnyDeviceCheck;
+
                 [XmlElement("Input")]
                 public List<EffectProperty> Inputs { get; set; }
 

--- a/tools/codegen/exe/Settings.xml
+++ b/tools/codegen/exe/Settings.xml
@@ -299,6 +299,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     </Effect>
     <Effect Name="OpacityEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="ID2D1Factory5"/>
     <Effect Name="TintEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="ID2D1Factory5"/>
-    <Effect Name="WhiteLevelAdjustmentEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedOnAnyDeviceCheck="Win10_17763"/>
+    <Effect Name="HdrToneMapEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedWithAnyDeviceCheck="Win10_17763"/>
+    <Effect Name="WhiteLevelAdjustmentEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedWithAnyDeviceCheck="Win10_17763"/>
   </Namespace>
 </Settings>

--- a/tools/codegen/exe/Settings.xml
+++ b/tools/codegen/exe/Settings.xml
@@ -299,7 +299,11 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     </Effect>
     <Effect Name="OpacityEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="ID2D1Factory5"/>
     <Effect Name="TintEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="ID2D1Factory5"/>
-    <Effect Name="HdrToneMapEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedWithAnyDeviceCheck="Win10_17763"/>
-    <Effect Name="WhiteLevelAdjustmentEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedWithAnyDeviceCheck="Win10_17763"/>
+    <Effect Name="HDRToneMapEffect" ProjectedNameOverride="HdrToneMapEffect" CLSIDOverride="CLSID_D2D1HdrToneMap" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="Registered"/>
+    <Enum Name="HDRToneMapEffectDisplayMode" ProjectedNameOverride="HdrToneMapEffectDisplayMode">
+      <Field Name="SDR" ProjectedNameOverride="Sdr"/>
+      <Field Name="HDR" ProjectedNameOverride="Hdr"/>
+    </Enum>
+    <Effect Name="WhiteLevelAdjustmentEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="Registered"/>
   </Namespace>
 </Settings>

--- a/tools/codegen/exe/Settings.xml
+++ b/tools/codegen/exe/Settings.xml
@@ -299,5 +299,6 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     </Effect>
     <Effect Name="OpacityEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="ID2D1Factory5"/>
     <Effect Name="TintEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedCheck="ID2D1Factory5"/>
+    <Effect Name="WhiteLevelAdjustmentEffect" WinVer="_WIN32_WINNT_WIN10" IsSupportedOnAnyDeviceCheck="Win10_17763"/>
   </Namespace>
 </Settings>

--- a/tools/codegen/exe/apiref/UpdateApiResourceFiles.cmd
+++ b/tools/codegen/exe/apiref/UpdateApiResourceFiles.cmd
@@ -97,6 +97,7 @@ SET FILE_LIST=^
     GammaTransfer.xml ^
     GaussianBlur.xml ^
     Grayscale.xml ^
+    HdrToneMap.xml ^
     HighlightsShadows.xml ^
     HueRotation.xml ^
     HueToRgb.xml ^
@@ -125,7 +126,8 @@ SET FILE_LIST=^
     Tint.xml ^
     Turbulence.xml ^
     UnPremultiply.xml ^
-    Vignette.xml
+    Vignette.xml ^
+    WhiteLevelAdjustment.xml
 
 CALL :UPDATE_FILES
 

--- a/tools/codegen/exe/apiref/UpdateApiResourceFiles.cmd
+++ b/tools/codegen/exe/apiref/UpdateApiResourceFiles.cmd
@@ -97,7 +97,7 @@ SET FILE_LIST=^
     GammaTransfer.xml ^
     GaussianBlur.xml ^
     Grayscale.xml ^
-    HdrToneMap.xml ^
+    HDRToneMap.xml ^
     HighlightsShadows.xml ^
     HueRotation.xml ^
     HueToRgb.xml ^

--- a/tools/codegen/exe/apiref/effects/HdrToneMap.xml
+++ b/tools/codegen/exe/apiref/effects/HdrToneMap.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+-->
+
+<Effect>
+    <!-- Localization -->
+    <_locDefinition>
+        <_locDefault _loc="locNone" />
+        <_locTag _locAttrData="displayname">Field</_locTag>
+        <_locTag _locAttrData="name">Input</_locTag>
+        <_locTag _locAttrData="value">Property</_locTag>
+    </_locDefinition>
+    <!-- System Properties -->
+    <Property name='DisplayName' type='string' value='HdrToneMap'/>
+    <Property name='Author' type='string' value='Microsoft Corporation'/>
+    <Property name='Category' type='string' value='Color'/>
+    <Property name='Description' type='string' 
+        value='This effect adjusts the dynamic range of an image to better suit its content to the capability of the output display.'/>
+
+    <Inputs>
+        <Input name='Source'/>
+    </Inputs>
+
+    <!-- Custom Properties -->
+    <Property name='InputMaxLuminance' type='float'>
+        <Property name='DisplayName' type='string' value='Input max luminance'/>
+        <Property name="Default" type="float" value="4000.0" />
+    </Property>
+  <Property name='OutputMaxLuminance' type='float'>
+    <Property name='DisplayName' type='string' value='Output max luminance'/>
+    <Property name="Default" type="float" value="300.0" />
+  </Property>
+  <Property name='DisplayMode' type='enum'>
+    <Property name='DisplayName' type='string' value='Display mode' />
+    <Property name='Default' type="enum" value='0' />
+    <Fields>
+      <Field name='Sdr' displayname='SDR' index="0" />
+      <Field name='Hdr' displayname='HDR' index="1" />
+    </Fields>
+  </Property>
+</Effect>

--- a/tools/codegen/exe/apiref/effects/HdrToneMap.xml
+++ b/tools/codegen/exe/apiref/effects/HdrToneMap.xml
@@ -14,31 +14,30 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
         <_locTag _locAttrData="value">Property</_locTag>
     </_locDefinition>
     <!-- System Properties -->
-    <Property name='DisplayName' type='string' value='HdrToneMap'/>
+    <Property name='DisplayName' type='string' value='HDR Tone Map'/>
     <Property name='Author' type='string' value='Microsoft Corporation'/>
     <Property name='Category' type='string' value='Color'/>
-    <Property name='Description' type='string' 
-        value='This effect adjusts the dynamic range of an image to better suit its content to the capability of the output display.'/>
+    <Property name='Description' type='string' value='Adjusts the maximum luminance of the source image to fit within the maximum output luminance supported. Input and output luminance values are specified in nits. Note that the color space of the image is assumed to be scRGB.'/>
 
+    <!-- This effect has one input -->
     <Inputs>
-        <Input name='Source'/>
+	    <Input name='Source'/>
     </Inputs>
 
-    <!-- Custom Properties -->
     <Property name='InputMaxLuminance' type='float'>
-        <Property name='DisplayName' type='string' value='Input max luminance'/>
-        <Property name="Default" type="float" value="4000.0" />
+        <Property name='DisplayName' type='string' value='Input Max Luminance'/>
+        <Property name="Default" type="float" value="4000" />
     </Property>
-  <Property name='OutputMaxLuminance' type='float'>
-    <Property name='DisplayName' type='string' value='Output max luminance'/>
-    <Property name="Default" type="float" value="300.0" />
-  </Property>
-  <Property name='DisplayMode' type='enum'>
-    <Property name='DisplayName' type='string' value='Display mode' />
-    <Property name='Default' type="enum" value='0' />
-    <Fields>
-      <Field name='Sdr' displayname='SDR' index="0" />
-      <Field name='Hdr' displayname='HDR' index="1" />
-    </Fields>
-  </Property>
+    <Property name="OutputMaxLuminance" type="float">
+        <Property name="DisplayName" type="string" value="Output Max Luminance" />
+        <Property name="Default" type="float" value="300" />
+    </Property>
+    <Property name='DisplayMode' type='enum'>
+        <Property name='DisplayName' type='string' value='Display Mode'/>
+        <Property name="Default" type="enum" value="0" />
+        <Fields>
+            <Field name='SDR' displayname='SDR' index="0" />
+            <Field name='HDR' displayname='HDR' index="1" />
+        </Fields>
+    </Property>
 </Effect>

--- a/tools/codegen/exe/apiref/effects/WhiteLevelAdjustment.xml
+++ b/tools/codegen/exe/apiref/effects/WhiteLevelAdjustment.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+-->
+
+<Effect>
+    <!-- Localization -->
+    <_locDefinition>
+        <_locDefault _loc="locNone" />
+        <_locTag _locAttrData="displayname">Field</_locTag>
+        <_locTag _locAttrData="name">Input</_locTag>
+        <_locTag _locAttrData="value">Property</_locTag>
+    </_locDefinition>
+    <!-- System Properties -->
+    <Property name='DisplayName' type='string' value='WhiteLevelAdjustment'/>
+    <Property name='Author' type='string' value='Microsoft Corporation'/>
+    <Property name='Category' type='string' value='Color'/>
+    <Property name='Description' type='string' 
+        value='This effect allows the white level of an image to be linearly scaled. This is especially helpful when you convert between display-referred luminance space and scene-referred luminance space, or vice versa.'/>
+
+    <Inputs>
+        <Input name='Source'/>
+    </Inputs>
+
+    <!-- Custom Properties -->
+    <Property name='InputWhiteLevel' type='float'>
+        <Property name='DisplayName' type='string' value='Input white level'/>
+        <Property name="Default" type="float" value="80.0" />
+    </Property>
+  <Property name='OutputWhiteLevel' type='float'>
+    <Property name='DisplayName' type='string' value='Output white level'/>
+    <Property name="Default" type="float" value="80.0" />
+  </Property>
+</Effect>

--- a/tools/codegen/exe/apiref/effects/WhiteLevelAdjustment.xml
+++ b/tools/codegen/exe/apiref/effects/WhiteLevelAdjustment.xml
@@ -14,23 +14,23 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
         <_locTag _locAttrData="value">Property</_locTag>
     </_locDefinition>
     <!-- System Properties -->
-    <Property name='DisplayName' type='string' value='WhiteLevelAdjustment'/>
+    <Property name='DisplayName' type='string' value='White Level Adjustment'/>
     <Property name='Author' type='string' value='Microsoft Corporation'/>
     <Property name='Category' type='string' value='Color'/>
     <Property name='Description' type='string' 
-        value='This effect allows the white level of an image to be linearly scaled. This is especially helpful when you convert between display-referred luminance space and scene-referred luminance space, or vice versa.'/>
+	    value='This effect adjusts the white level of the source image by multiplying the source image color by the ratio of the input and output white levels. Input and output white levels are specified in nits.'/>
 
+    <!-- This effect have one input -->
     <Inputs>
-        <Input name='Source'/>
+	    <Input name='Source'/>
     </Inputs>
 
-    <!-- Custom Properties -->
     <Property name='InputWhiteLevel' type='float'>
-        <Property name='DisplayName' type='string' value='Input white level'/>
-        <Property name="Default" type="float" value="80.0" />
+        <Property name='DisplayName' type='string' value='Input White Level'/>
+        <Property name="Default" type="float" value="80" />
     </Property>
-  <Property name='OutputWhiteLevel' type='float'>
-    <Property name='DisplayName' type='string' value='Output white level'/>
-    <Property name="Default" type="float" value="80.0" />
-  </Property>
+    <Property name="OutputWhiteLevel" type="float">
+        <Property name="DisplayName" type="string" value="Output White Level" />
+        <Property name="Default" type="float" value="80" />
+    </Property>
 </Effect>

--- a/tools/codegen/exe/codegen.exe.csproj
+++ b/tools/codegen/exe/codegen.exe.csproj
@@ -128,6 +128,7 @@
     <None Include="apiref\effects\CrossFade.xml" />
     <None Include="apiref\effects\Opacity.xml" />
     <None Include="apiref\effects\Tint.xml" />
+    <None Include="apiref\effects\WhiteLevelAdjustment.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tools/codegen/exe/codegen.exe.csproj
+++ b/tools/codegen/exe/codegen.exe.csproj
@@ -128,6 +128,7 @@
     <None Include="apiref\effects\CrossFade.xml" />
     <None Include="apiref\effects\Opacity.xml" />
     <None Include="apiref\effects\Tint.xml" />
+    <None Include="apiref\effects\HdrToneMap.xml" />
     <None Include="apiref\effects\WhiteLevelAdjustment.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tools/codegen/test/UnitTests.cs
+++ b/tools/codegen/test/UnitTests.cs
@@ -82,7 +82,7 @@ namespace CodeGen.Test
             FileInfo[] actualGeneratedFiles = actualDirectoryInfo.GetFiles();
 
             // Ensure the correct number of files was generated.
-            const int expectedEffectCount = 59;
+            const int expectedEffectCount = 61;
             Assert.AreEqual(expectedEffectCount * 3 + 2, expectedGeneratedFiles.Length);
             Assert.AreEqual(expectedGeneratedFiles.Length, actualGeneratedFiles.Length);
 

--- a/tools/docs/DocPreprocess/Tag.cs
+++ b/tools/docs/DocPreprocess/Tag.cs
@@ -12,6 +12,7 @@ namespace DocPreprocess
             new Tag("Win10_10586", "This API is only available when running on Windows 10 build 10586 (released November 2015) or greater.") { PropagateTypeTagsToMembers = true },
             new Tag("Win10_14393", "This API is only available when running on Windows 10 build 14393 (Anniversary Update) or greater.") { PropagateTypeTagsToMembers = true },
             new Tag("Win10_15063", "This API is only available when running on Windows 10 build 15063 (Creators Update) or greater.") { PropagateTypeTagsToMembers = true },
+            new Tag("Win10_17763", "This API is only available when running on Windows 10 build 17763 (October 2018) or greater.") { PropagateTypeTagsToMembers = true },
             new Tag("NoComposition", "Supported by Win2D but not Windows.UI.Composition."),
         };
 

--- a/winrt/docsrc/effects/AlphaMaskEffect.xml
+++ b/winrt/docsrc/effects/AlphaMaskEffect.xml
@@ -36,7 +36,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     
     <inherittemplate name="EffectTemplate" replacement="AlphaMaskEffect" />
     <inherittemplate name="ICanvasEffectTemplate" replacement="AlphaMaskEffect" />
-    <inherittemplate name="EffectRequires14393Template" replacement="AlphaMaskEffect" />
+    <inherittemplate name="EffectRequiresOSVersionTemplate" replacement="AlphaMaskEffect" />
 
   </members>
 </doc>

--- a/winrt/docsrc/effects/CrossFadeEffect.xml
+++ b/winrt/docsrc/effects/CrossFadeEffect.xml
@@ -40,7 +40,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     
     <inherittemplate name="EffectTemplate" replacement="CrossFadeEffect" />
     <inherittemplate name="ICanvasEffectTemplate" replacement="CrossFadeEffect" />
-    <inherittemplate name="EffectRequires14393Template" replacement="CrossFadeEffect" />
+    <inherittemplate name="EffectRequiresOSVersionTemplate" replacement="CrossFadeEffect" />
 
   </members>
 </doc>

--- a/winrt/docsrc/effects/Effects.xml
+++ b/winrt/docsrc/effects/Effects.xml
@@ -198,36 +198,17 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
   </template>
 
 
-  <template name="EffectRequires14393Template">
-    <member name="P:Microsoft.Graphics.Canvas.Effects.EffectRequires14393Template.IsSupported" Win10_14393="false">
-      <summary>Checks whether EffectRequires14393Template is supported on the current operating system version.</summary>
+  <template name="EffectRequiresOSVersionTemplate">
+    <member name="P:Microsoft.Graphics.Canvas.Effects.EffectRequiresOSVersionTemplate.IsSupported" Win10_14393="false" Win10_17763="false">
+      <summary>Checks whether EffectRequiresOSVersionTemplate is supported on the current operating system version.</summary>
       <remarks>
         <p>
           If the application is currently running on an operating system that doesn't
-          support EffectRequires14393Template then calls to create this effect will fail.
+          support EffectRequiresOSVersionTemplate then calls to create this effect will fail.
         </p>
         <p>
           If you know that your application will never run on an operating system that
-          doesn't support EffectRequires14393Template then there is no need to perform this check.
-        </p>
-      </remarks>
-    </member>
-  </template>
-
-  <template name="EffectRequires17763Template">
-    <member name="M:Microsoft.Graphics.Canvas.Effects.EffectRequires17763Template.IsSupported(Microsoft.Graphics.Canvas.CanvasDevice)" Win10_17763="false">
-      <summary>Checks whether EffectRequires17763Template is supported on the current operating system version.</summary>
-      <remarks>
-        <p>
-          The device parameter can be any (valid) device. The result is cached internally so subsequent calls are fast. May throw an excaption if the device is in an invalid state, e.g. already closed.
-        </p>
-        <p>
-          If the application is currently running on an operating system that doesn't
-          support EffectRequires17763Template then calls to create this effect will fail.
-        </p>
-        <p>
-          If you know that your application will never run on an operating system that
-          doesn't support EffectRequires17763Template then there is no need to perform this check.
+          doesn't support EffectRequiresOSVersionTemplate then there is no need to perform this check.
         </p>
       </remarks>
     </member>

--- a/winrt/docsrc/effects/Effects.xml
+++ b/winrt/docsrc/effects/Effects.xml
@@ -215,7 +215,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
   </template>
 
   <template name="EffectRequires17763Template">
-    <member name="P:Microsoft.Graphics.Canvas.Effects.EffectRequires17763Template.IsSupported(Microsoft.Graphics.Canvas.ICanvasDevice)" Win10_17763="false">
+    <member name="M:Microsoft.Graphics.Canvas.Effects.EffectRequires17763Template.IsSupported(Microsoft.Graphics.Canvas.CanvasDevice)" Win10_17763="false">
       <summary>Checks whether EffectRequires17763Template is supported on the current operating system version.</summary>
       <remarks>
         <p>

--- a/winrt/docsrc/effects/Effects.xml
+++ b/winrt/docsrc/effects/Effects.xml
@@ -214,4 +214,23 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     </member>
   </template>
 
+  <template name="EffectRequires17763Template">
+    <member name="P:Microsoft.Graphics.Canvas.Effects.EffectRequires17763Template.IsSupported(Microsoft.Graphics.Canvas.ICanvasDevice)" Win10_17763="false">
+      <summary>Checks whether EffectRequires17763Template is supported on the current operating system version.</summary>
+      <remarks>
+        <p>
+          The device parameter can be any (valid) device. The result is cached internally so subsequent calls are fast. May throw an excaption if the device is in an invalid state, e.g. already closed.
+        </p>
+        <p>
+          If the application is currently running on an operating system that doesn't
+          support EffectRequires17763Template then calls to create this effect will fail.
+        </p>
+        <p>
+          If you know that your application will never run on an operating system that
+          doesn't support EffectRequires17763Template then there is no need to perform this check.
+        </p>
+      </remarks>
+    </member>
+  </template>
+
 </doc>

--- a/winrt/docsrc/effects/HdrToneMapEffect.xml
+++ b/winrt/docsrc/effects/HdrToneMapEffect.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+-->
+
+<doc>
+  <assembly>
+    <name>Microsoft.Graphics.Canvas</name>
+  </assembly>
+  <members>
+
+    <member name="T:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect" Win10_17763="true">
+      <summary>
+        This effect adjusts the dynamic range of an image to better suit its content to the capability of the output display.
+      </summary>
+      <remarks>
+        <p>This Windows Runtime type corresponds to the 
+          <a href="https://docs.microsoft.com/en-us/windows/win32/direct2d/hdr-tone-map-effect">D2D HDR tone map effect</a>.</p>
+      </remarks>
+    </member>
+    <member name="M:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.#ctor">
+      <summary>Initializes a new instance of the HdrToneMapEffect class.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.Source">
+      <summary>Gets or sets the input source for the effect.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.InputMaxLuminance">
+      <summary>The maximum light level (or MaxCLL) of the image, in nits. Default value 80.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.OutputMaxLuminance">
+      <summary>The MaxCLL supported by the output target, in nits—typically set to the MaxCLL of the display. Default value 80.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.DisplayMode">
+      <summary>When set to Hdr, the tone mapping curve is adjusted to better fit the fit the behavior of common HDR displays. Default value Sdr.</summary>
+    </member>
+    
+    <inherittemplate name="EffectTemplate" replacement="HdrToneMapEffect" />
+    <inherittemplate name="ICanvasEffectTemplate" replacement="HdrToneMapEffect" />
+    <inherittemplate name="EffectRequires17763Template" replacement="HdrToneMapEffect" />
+
+  </members>
+</doc>

--- a/winrt/docsrc/effects/HdrToneMapEffect.xml
+++ b/winrt/docsrc/effects/HdrToneMapEffect.xml
@@ -11,7 +11,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
   </assembly>
   <members>
 
-    <member name="T:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect" Win10_17763="true">
+    <member name="T:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect" NoComposition="true" Win10_17763="true">
       <summary>
         This effect adjusts the dynamic range of an image to better suit its content to the capability of the output display.
       </summary>

--- a/winrt/docsrc/effects/HdrToneMapEffect.xml
+++ b/winrt/docsrc/effects/HdrToneMapEffect.xml
@@ -48,7 +48,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     
     <inherittemplate name="EffectTemplate" replacement="HdrToneMapEffect" />
     <inherittemplate name="ICanvasEffectTemplate" replacement="HdrToneMapEffect" />
-    <inherittemplate name="EffectRequires17763Template" replacement="HdrToneMapEffect" />
+    <inherittemplate name="EffectRequiresOSVersionTemplate" replacement="HdrToneMapEffect" />
 
   </members>
 </doc>

--- a/winrt/docsrc/effects/HdrToneMapEffect.xml
+++ b/winrt/docsrc/effects/HdrToneMapEffect.xml
@@ -27,13 +27,23 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
       <summary>Gets or sets the input source for the effect.</summary>
     </member>
     <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.InputMaxLuminance">
-      <summary>The maximum light level (or MaxCLL) of the image, in nits. Default value 80.</summary>
+      <summary>The maximum light level (or MaxCLL) of the image, in nits. Default value 4000.</summary>
     </member>
     <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.OutputMaxLuminance">
-      <summary>The MaxCLL supported by the output target, in nits—typically set to the MaxCLL of the display. Default value 80.</summary>
+      <summary>The MaxCLL supported by the output target, in nits - typically set to the MaxCLL of the display. Default value 300.</summary>
     </member>
     <member name="P:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffect.DisplayMode">
       <summary>When set to Hdr, the tone mapping curve is adjusted to better fit the fit the behavior of common HDR displays. Default value Sdr.</summary>
+    </member>
+
+    <member name="T:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffectDisplayMode">
+      <summary>The display mode used for the effect.</summary>
+    </member>
+    <member name="F:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffectDisplayMode.Sdr">
+      <summary>Specifies that the tone mapper algorithm be optimized for best appearance on a standard dynamic range (SDR) display.</summary>
+    </member>
+    <member name="F:Microsoft.Graphics.Canvas.Effects.HdrToneMapEffectDisplayMode.Hdr">
+      <summary>Specifies that the tone mapper algorithm be optimized for best appearance on a high dynamic range (HDR) display.</summary>
     </member>
     
     <inherittemplate name="EffectTemplate" replacement="HdrToneMapEffect" />

--- a/winrt/docsrc/effects/OpacityEffect.xml
+++ b/winrt/docsrc/effects/OpacityEffect.xml
@@ -32,7 +32,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     
     <inherittemplate name="EffectTemplate" replacement="OpacityEffect" />
     <inherittemplate name="ICanvasEffectTemplate" replacement="OpacityEffect" />
-    <inherittemplate name="EffectRequires14393Template" replacement="OpacityEffect" />
+    <inherittemplate name="EffectRequiresOSVersionTemplate" replacement="OpacityEffect" />
 
   </members>
 </doc>

--- a/winrt/docsrc/effects/TintEffect.xml
+++ b/winrt/docsrc/effects/TintEffect.xml
@@ -56,7 +56,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     
     <inherittemplate name="EffectTemplate" replacement="TintEffect" />
     <inherittemplate name="ICanvasEffectTemplate" replacement="TintEffect" />
-    <inherittemplate name="EffectRequires14393Template" replacement="TintEffect" />
+    <inherittemplate name="EffectRequiresOSVersionTemplate" replacement="TintEffect" />
 
   </members>
 </doc>

--- a/winrt/docsrc/effects/WhiteLevelAdjustmentEffect.xml
+++ b/winrt/docsrc/effects/WhiteLevelAdjustmentEffect.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+-->
+
+<doc>
+  <assembly>
+    <name>Microsoft.Graphics.Canvas</name>
+  </assembly>
+  <members>
+
+    <member name="T:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect" Win10_17763="true">
+      <summary>
+        This effect allows the white level of an image to be linearly scaled. This is especially helpful when you convert between display-referred luminance space and scene-referred luminance space, or vice versa.
+      </summary>
+      <remarks>
+        <p>This Windows Runtime type corresponds to the 
+          <a href="https://docs.microsoft.com/en-us/windows/win32/direct2d/white-level-adjustment-effect">D2D White level adjustment effect</a>.</p>
+      </remarks>
+    </member>
+    <member name="M:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect.#ctor">
+      <summary>Initializes a new instance of the WhiteLevelAdjustmentEffect class.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect.Source">
+      <summary>Gets or sets the input source for the effect.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect.InputWhiteLevel">
+      <summary>The white level of the input image, in nits. Default value 80.</summary>
+    </member>
+    <member name="P:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect.OutputWhiteLevel">
+      <summary>The white level of the output image, in nits. Default value 80.</summary>
+    </member>
+    
+    <inherittemplate name="EffectTemplate" replacement="WhiteLevelAdjustmentEffect" />
+    <inherittemplate name="ICanvasEffectTemplate" replacement="WhiteLevelAdjustmentEffect" />
+    <inherittemplate name="EffectRequires17763Template" replacement="WhiteLevelAdjustmentEffect" />
+
+  </members>
+</doc>

--- a/winrt/docsrc/effects/WhiteLevelAdjustmentEffect.xml
+++ b/winrt/docsrc/effects/WhiteLevelAdjustmentEffect.xml
@@ -11,7 +11,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
   </assembly>
   <members>
 
-    <member name="T:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect" Win10_17763="true">
+    <member name="T:Microsoft.Graphics.Canvas.Effects.WhiteLevelAdjustmentEffect" NoComposition="true" Win10_17763="true">
       <summary>
         This effect allows the white level of an image to be linearly scaled. This is especially helpful when you convert between display-referred luminance space and scene-referred luminance space, or vice versa.
       </summary>

--- a/winrt/docsrc/effects/WhiteLevelAdjustmentEffect.xml
+++ b/winrt/docsrc/effects/WhiteLevelAdjustmentEffect.xml
@@ -35,7 +35,7 @@ Licensed under the MIT License. See LICENSE.txt in the project root for license 
     
     <inherittemplate name="EffectTemplate" replacement="WhiteLevelAdjustmentEffect" />
     <inherittemplate name="ICanvasEffectTemplate" replacement="WhiteLevelAdjustmentEffect" />
-    <inherittemplate name="EffectRequires17763Template" replacement="WhiteLevelAdjustmentEffect" />
+    <inherittemplate name="EffectRequiresOSVersionTemplate" replacement="WhiteLevelAdjustmentEffect" />
 
   </members>
 </doc>

--- a/winrt/lib/Canvas.abi.idl
+++ b/winrt/lib/Canvas.abi.idl
@@ -93,6 +93,7 @@ cpp_quote("#endif")
 #include "effects\generated\GammaTransferEffect.abi.idl"
 #include "effects\generated\GaussianBlurEffect.abi.idl"
 #include "effects\generated\GrayscaleEffect.abi.idl"
+#include "effects\generated\HdrToneMapEffect.abi.idl"
 #include "effects\generated\HighlightsAndShadowsEffect.abi.idl"
 #include "effects\generated\HueRotationEffect.abi.idl"
 #include "effects\generated\HueToRgbEffect.abi.idl"

--- a/winrt/lib/Canvas.abi.idl
+++ b/winrt/lib/Canvas.abi.idl
@@ -125,3 +125,4 @@ cpp_quote("#endif")
 #include "effects\generated\TurbulenceEffect.abi.idl"
 #include "effects\generated\UnPremultiplyEffect.abi.idl"
 #include "effects\generated\VignetteEffect.abi.idl"
+#include "effects\generated\WhiteLevelAdjustmentEffect.abi.idl"

--- a/winrt/lib/drawing/CanvasDevice.cpp
+++ b/winrt/lib/drawing/CanvasDevice.cpp
@@ -335,7 +335,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         ComPtr<ID2D1Properties> effectProperties;
         auto hr = factory->GetEffectProperties(effectId, effectProperties.GetAddressOf());
         bool result = true;
-        if (hr == D2DERR_EFFECT_IS_NOT_REGISTERED) {
+        if (hr == D2DERR_EFFECT_IS_NOT_REGISTERED || hr == E_NOT_SET) { //E_NOT_SET is returned for UWP apps if the effect is not registered
             result = false;
         } else {
             ThrowIfFailed(hr);

--- a/winrt/lib/drawing/CanvasDevice.cpp
+++ b/winrt/lib/drawing/CanvasDevice.cpp
@@ -323,7 +323,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         return !!m_isID2D1Factory5Supported;
     }
 
-    bool SharedDeviceState::IsEffectSupportedOnAnyDevice(ICanvasDevice* device, IID const& effectId, std::wstring const& key) {
+    bool SharedDeviceState::IsEffectSupportedWithAnyDevice(ICanvasDevice* device, IID const& effectId, std::wstring const& key) {
         CheckInPointer(device);
         {
             RecursiveLock lock(m_mutex);
@@ -335,10 +335,8 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         auto lease = As<ICanvasDeviceInternal>(device)->GetResourceCreationDeviceContext();
         ComPtr<ID2D1Effect> pEffect;
         auto hr = lease->CreateEffect(effectId, pEffect.GetAddressOf());
-        bool result;
-        if (hr == S_OK) {
-            result = true;
-        } else if (hr == E_NOT_SET) {
+        bool result = true;
+        if (hr == E_NOT_SET) {
             result = false;
         } else {
             ThrowIfFailed(hr);

--- a/winrt/lib/drawing/CanvasDevice.cpp
+++ b/winrt/lib/drawing/CanvasDevice.cpp
@@ -334,12 +334,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         auto factory = m_adapter->CreateD2DFactory(CanvasDebugLevel::None);
         ComPtr<ID2D1Properties> effectProperties;
         auto hr = factory->GetEffectProperties(effectId, effectProperties.GetAddressOf());
-        bool result = true;
-        if (hr == D2DERR_EFFECT_IS_NOT_REGISTERED || hr == E_NOT_SET) { //E_NOT_SET is returned for UWP apps if the effect is not registered
-            result = false;
-        } else {
-            ThrowIfFailed(hr);
-        }
+        bool result = SUCCEEDED(hr);
         if (cacheResult){
             RecursiveLock lock(m_mutex);
             m_cachedRegisteredEffects.insert_or_assign(effectId, result);

--- a/winrt/lib/drawing/CanvasDevice.h
+++ b/winrt/lib/drawing/CanvasDevice.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "DeviceContextPool.h"
+#include "Utils/GuidUtilities.h"
 
 namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
 {
@@ -426,7 +427,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         CanvasDebugLevel m_currentDebugLevel;
 
         int m_isID2D1Factory5Supported; // negative = not yet checked.
-        std::unordered_map<std::wstring, bool> m_supportedEffects;
+        std::map<const IID, bool, GuidComparer> m_cachedRegisteredEffects;
 
         std::recursive_mutex m_mutex;
 
@@ -441,7 +442,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         void SetDebugLevel(CanvasDebugLevel const& value);
 
         bool IsID2D1Factory5Supported();
-        bool IsEffectSupportedWithAnyDevice(ICanvasDevice* device, IID const& effectId, std::wstring const& key);
+        bool IsEffectRegistered(IID const& effectId, bool cacheResult); //Only set cacheResult to true for built-in effects, which cannot be unregistered.
 
         CanvasDeviceAdapter* GetAdapter() const { return m_adapter.get(); }
 

--- a/winrt/lib/drawing/CanvasDevice.h
+++ b/winrt/lib/drawing/CanvasDevice.h
@@ -441,7 +441,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         void SetDebugLevel(CanvasDebugLevel const& value);
 
         bool IsID2D1Factory5Supported();
-        bool IsEffectSupportedOnAnyDevice(ICanvasDevice* device, IID const& effectId, std::wstring const& key);
+        bool IsEffectSupportedWithAnyDevice(ICanvasDevice* device, IID const& effectId, std::wstring const& key);
 
         CanvasDeviceAdapter* GetAdapter() const { return m_adapter.get(); }
 

--- a/winrt/lib/drawing/CanvasDevice.h
+++ b/winrt/lib/drawing/CanvasDevice.h
@@ -426,6 +426,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         CanvasDebugLevel m_currentDebugLevel;
 
         int m_isID2D1Factory5Supported; // negative = not yet checked.
+        std::unordered_map<std::wstring, bool> m_supportedEffects;
 
         std::recursive_mutex m_mutex;
 
@@ -440,6 +441,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         void SetDebugLevel(CanvasDebugLevel const& value);
 
         bool IsID2D1Factory5Supported();
+        bool IsEffectSupportedOnAnyDevice(ICanvasDevice* device, IID const& effectId, std::wstring const& key);
 
         CanvasDeviceAdapter* GetAdapter() const { return m_adapter.get(); }
 

--- a/winrt/lib/effects/generated/EffectMakers.cpp
+++ b/winrt/lib/effects/generated/EffectMakers.cpp
@@ -68,6 +68,7 @@
 #include "TemperatureAndTintEffect.h"
 #include "TintEffect.h"
 #include "VignetteEffect.h"
+#include "WhiteLevelAdjustmentEffect.h"
 
 #endif // _WIN32_WINNT_WIN10
 
@@ -136,6 +137,7 @@ std::pair<IID, CanvasEffect::MakeEffectFunction> CanvasEffect::m_effectMakers[] 
     { TemperatureAndTintEffect::EffectId(),   MakeEffect<TemperatureAndTintEffect>   },
     { TintEffect::EffectId(),                 MakeEffect<TintEffect>                 },
     { VignetteEffect::EffectId(),             MakeEffect<VignetteEffect>             },
+    { WhiteLevelAdjustmentEffect::EffectId(), MakeEffect<WhiteLevelAdjustmentEffect> },
 
 #endif // _WIN32_WINNT_WIN10
 

--- a/winrt/lib/effects/generated/EffectMakers.cpp
+++ b/winrt/lib/effects/generated/EffectMakers.cpp
@@ -55,6 +55,7 @@
 #include "EmbossEffect.h"
 #include "ExposureEffect.h"
 #include "GrayscaleEffect.h"
+#include "HdrToneMapEffect.h"
 #include "HighlightsAndShadowsEffect.h"
 #include "HueToRgbEffect.h"
 #include "InvertEffect.h"
@@ -124,6 +125,7 @@ std::pair<IID, CanvasEffect::MakeEffectFunction> CanvasEffect::m_effectMakers[] 
     { EmbossEffect::EffectId(),               MakeEffect<EmbossEffect>               },
     { ExposureEffect::EffectId(),             MakeEffect<ExposureEffect>             },
     { GrayscaleEffect::EffectId(),            MakeEffect<GrayscaleEffect>            },
+    { HdrToneMapEffect::EffectId(),           MakeEffect<HdrToneMapEffect>           },
     { HighlightsAndShadowsEffect::EffectId(), MakeEffect<HighlightsAndShadowsEffect> },
     { HueToRgbEffect::EffectId(),             MakeEffect<HueToRgbEffect>             },
     { InvertEffect::EffectId(),               MakeEffect<InvertEffect>               },

--- a/winrt/lib/effects/generated/HdrToneMapEffect.abi.idl
+++ b/winrt/lib/effects/generated/HdrToneMapEffect.abi.idl
@@ -50,7 +50,7 @@ namespace Microsoft.Graphics.Canvas.Effects
     [version(VERSION), uuid(0181F02F-0A7E-55E1-8D2D-42AB99739B27), exclusiveto(HdrToneMapEffect)]
     interface IHdrToneMapEffectStatics : IInspectable
     {
-        HRESULT IsSupported([in] Microsoft.Graphics.Canvas.CanvasDevice* device, [out, retval] boolean* result);
+        [propget] HRESULT IsSupported([out, retval] boolean* value);
     }
 
     [STANDARD_ATTRIBUTES, activatable(VERSION), static(IHdrToneMapEffectStatics, VERSION)]

--- a/winrt/lib/effects/generated/HdrToneMapEffect.abi.idl
+++ b/winrt/lib/effects/generated/HdrToneMapEffect.abi.idl
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// This file was automatically generated. Please do not edit it manually.
+
+#if (defined _WIN32_WINNT_WIN10) && (WINVER >= _WIN32_WINNT_WIN10)
+
+namespace Microsoft.Graphics.Canvas.Effects
+{
+    [version(VERSION)]
+    typedef enum HdrToneMapEffectDisplayMode
+    {
+        Sdr = 0,
+        Hdr = 1
+    } HdrToneMapEffectDisplayMode;
+
+    runtimeclass HdrToneMapEffect;
+
+    [version(VERSION), uuid(2004FAAC-663E-5DF4-B4CD-A5AFBFD9341F), exclusiveto(HdrToneMapEffect)]
+    interface IHdrToneMapEffect : IInspectable
+        requires ICanvasEffect
+    {
+        [propget]
+        HRESULT InputMaxLuminance([out, retval] float* value);
+
+        [propput]
+        HRESULT InputMaxLuminance([in] float value);
+
+        [propget]
+        HRESULT OutputMaxLuminance([out, retval] float* value);
+
+        [propput]
+        HRESULT OutputMaxLuminance([in] float value);
+
+        [propget]
+        HRESULT DisplayMode([out, retval] HdrToneMapEffectDisplayMode* value);
+
+        [propput]
+        HRESULT DisplayMode([in] HdrToneMapEffectDisplayMode value);
+
+        [propget]
+        HRESULT Source([out, retval] IGRAPHICSEFFECTSOURCE** source);
+
+        [propput]
+        HRESULT Source([in] IGRAPHICSEFFECTSOURCE* source);
+
+    };
+
+    [version(VERSION), uuid(0181F02F-0A7E-55E1-8D2D-42AB99739B27), exclusiveto(HdrToneMapEffect)]
+    interface IHdrToneMapEffectStatics : IInspectable
+    {
+        HRESULT IsSupported([in] Microsoft.Graphics.Canvas.CanvasDevice* device, [out, retval] boolean* result);
+    }
+
+    [STANDARD_ATTRIBUTES, activatable(VERSION), static(IHdrToneMapEffectStatics, VERSION)]
+    runtimeclass HdrToneMapEffect
+    {
+        [default] interface IHdrToneMapEffect;
+    }
+}
+
+#endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/HdrToneMapEffect.cpp
+++ b/winrt/lib/effects/generated/HdrToneMapEffect.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// This file was automatically generated. Please do not edit it manually.
+
+#include "pch.h"
+#include "HdrToneMapEffect.h"
+
+#if (defined _WIN32_WINNT_WIN10) && (WINVER >= _WIN32_WINNT_WIN10)
+
+namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { namespace Effects
+{
+    HdrToneMapEffect::HdrToneMapEffect(ICanvasDevice* device, ID2D1Effect* effect)
+        : CanvasEffect(EffectId(), 3, 1, true, device, effect, static_cast<IHdrToneMapEffect*>(this))
+    {
+        if (!effect)
+        {
+            // Set default values
+            SetBoxedProperty<float>(D2D1_HDRTONEMAP_PROP_INPUT_MAX_LUMINANCE, 4000.0f);
+            SetBoxedProperty<float>(D2D1_HDRTONEMAP_PROP_OUTPUT_MAX_LUMINANCE, 300.0f);
+            SetBoxedProperty<uint32_t>(D2D1_HDRTONEMAP_PROP_DISPLAY_MODE, HdrToneMapEffectDisplayMode::Sdr);
+        }
+    }
+
+    IMPLEMENT_EFFECT_PROPERTY(HdrToneMapEffect,
+        InputMaxLuminance,
+        float,
+        float,
+        D2D1_HDRTONEMAP_PROP_INPUT_MAX_LUMINANCE)
+
+    IMPLEMENT_EFFECT_PROPERTY(HdrToneMapEffect,
+        OutputMaxLuminance,
+        float,
+        float,
+        D2D1_HDRTONEMAP_PROP_OUTPUT_MAX_LUMINANCE)
+
+    IMPLEMENT_EFFECT_PROPERTY(HdrToneMapEffect,
+        DisplayMode,
+        uint32_t,
+        HdrToneMapEffectDisplayMode,
+        D2D1_HDRTONEMAP_PROP_DISPLAY_MODE)
+
+    IMPLEMENT_EFFECT_SOURCE_PROPERTY(HdrToneMapEffect,
+        Source,
+        0)
+
+    IMPLEMENT_EFFECT_PROPERTY_MAPPING(HdrToneMapEffect,
+        { L"InputMaxLuminance",  D2D1_HDRTONEMAP_PROP_INPUT_MAX_LUMINANCE,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
+        { L"OutputMaxLuminance", D2D1_HDRTONEMAP_PROP_OUTPUT_MAX_LUMINANCE, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
+        { L"DisplayMode",        D2D1_HDRTONEMAP_PROP_DISPLAY_MODE,         GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
+
+    IFACEMETHODIMP HdrToneMapEffectFactory::ActivateInstance(IInspectable** instance)
+    {
+        return ExceptionBoundary([&]
+        {
+            auto effect = Make<HdrToneMapEffect>();
+            CheckMakeResult(effect);
+
+            ThrowIfFailed(effect.CopyTo(instance));
+        });
+    }
+
+    IFACEMETHODIMP HdrToneMapEffectFactory::IsSupported(ICanvasDevice* device, boolean* result)
+    {
+        return ExceptionBoundary([&]
+        {
+            CheckInPointer(device);
+            CheckInPointer(result);
+            *result = SharedDeviceState::GetInstance()->IsEffectSupportedWithAnyDevice(device, HdrToneMapEffect::EffectId(), L"Win10_17763");
+        });
+    }
+
+    ActivatableClassWithFactory(HdrToneMapEffect, HdrToneMapEffectFactory);
+}}}}}
+
+#endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/HdrToneMapEffect.cpp
+++ b/winrt/lib/effects/generated/HdrToneMapEffect.cpp
@@ -14,6 +14,9 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     HdrToneMapEffect::HdrToneMapEffect(ICanvasDevice* device, ID2D1Effect* effect)
         : CanvasEffect(EffectId(), 3, 1, true, device, effect, static_cast<IHdrToneMapEffect*>(this))
     {
+        if (!SharedDeviceState::GetInstance()->IsEffectRegistered(HdrToneMapEffect::EffectId(), true))
+            ThrowHR(E_NOTIMPL, Strings::NotSupportedOnThisVersionOfWindows);
+
         if (!effect)
         {
             // Set default values
@@ -61,13 +64,12 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         });
     }
 
-    IFACEMETHODIMP HdrToneMapEffectFactory::IsSupported(ICanvasDevice* device, boolean* result)
+    IFACEMETHODIMP HdrToneMapEffectFactory::get_IsSupported(_Out_ boolean* result)
     {
         return ExceptionBoundary([&]
         {
-            CheckInPointer(device);
             CheckInPointer(result);
-            *result = SharedDeviceState::GetInstance()->IsEffectSupportedWithAnyDevice(device, HdrToneMapEffect::EffectId(), L"Win10_17763");
+            *result = SharedDeviceState::GetInstance()->IsEffectRegistered(HdrToneMapEffect::EffectId(), true);
         });
     }
 

--- a/winrt/lib/effects/generated/HdrToneMapEffect.h
+++ b/winrt/lib/effects/generated/HdrToneMapEffect.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// This file was automatically generated. Please do not edit it manually.
+
+#pragma once
+
+#if (defined _WIN32_WINNT_WIN10) && (WINVER >= _WIN32_WINNT_WIN10)
+
+namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { namespace Effects 
+{
+    using namespace ::Microsoft::WRL;
+    using namespace ABI::Microsoft::Graphics::Canvas;
+
+    class HdrToneMapEffect : public RuntimeClass<
+        IHdrToneMapEffect,
+        MixIn<HdrToneMapEffect, CanvasEffect>>,
+        public CanvasEffect
+    {
+        InspectableClass(RuntimeClass_Microsoft_Graphics_Canvas_Effects_HdrToneMapEffect, BaseTrust);
+
+    public:
+        HdrToneMapEffect(ICanvasDevice* device = nullptr, ID2D1Effect* effect = nullptr);
+
+        static IID const& EffectId() { return CLSID_D2D1HdrToneMap; }
+
+        EFFECT_PROPERTY(InputMaxLuminance, float);
+        EFFECT_PROPERTY(OutputMaxLuminance, float);
+        EFFECT_PROPERTY(DisplayMode, HdrToneMapEffectDisplayMode);
+        EFFECT_PROPERTY(Source, IGraphicsEffectSource*);
+
+        EFFECT_PROPERTY_MAPPING();
+    };
+
+    class HdrToneMapEffectFactory
+        : public AgileActivationFactory<IHdrToneMapEffectStatics>
+        , private LifespanTracker<HdrToneMapEffectFactory>
+    {
+        InspectableClassStatic(RuntimeClass_Microsoft_Graphics_Canvas_Effects_HdrToneMapEffect, BaseTrust);
+
+    public:
+        IFACEMETHODIMP ActivateInstance(IInspectable**) override;
+        IFACEMETHOD(IsSupported)(ICanvasDevice* device, boolean* result) override;
+    };
+}}}}}
+
+#endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/HdrToneMapEffect.h
+++ b/winrt/lib/effects/generated/HdrToneMapEffect.h
@@ -41,7 +41,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
 
     public:
         IFACEMETHODIMP ActivateInstance(IInspectable**) override;
-        IFACEMETHOD(IsSupported)(ICanvasDevice* device, boolean* result) override;
+        IFACEMETHOD(get_IsSupported)(boolean* value) override;
     };
 }}}}}
 

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.abi.idl
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.abi.idl
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// This file was automatically generated. Please do not edit it manually.
+
+#if (defined _WIN32_WINNT_WIN10) && (WINVER >= _WIN32_WINNT_WIN10)
+
+namespace Microsoft.Graphics.Canvas.Effects
+{
+    runtimeclass WhiteLevelAdjustmentEffect;
+
+    [version(VERSION), uuid(0B0B945C-96F7-56B4-8317-01DE629FC904), exclusiveto(WhiteLevelAdjustmentEffect)]
+    interface IWhiteLevelAdjustmentEffect : IInspectable
+        requires ICanvasEffect
+    {
+        [propget]
+        HRESULT InputWhiteLevel([out, retval] float* value);
+
+        [propput]
+        HRESULT InputWhiteLevel([in] float value);
+
+        [propget]
+        HRESULT OutputWhiteLevel([out, retval] float* value);
+
+        [propput]
+        HRESULT OutputWhiteLevel([in] float value);
+
+        [propget]
+        HRESULT Source([out, retval] IGRAPHICSEFFECTSOURCE** source);
+
+        [propput]
+        HRESULT Source([in] IGRAPHICSEFFECTSOURCE* source);
+
+    };
+
+    [version(VERSION), uuid(58DACBF8-637A-5DA7-9457-1EEEDF5A191C), exclusiveto(WhiteLevelAdjustmentEffect)]
+    interface IWhiteLevelAdjustmentEffectStatics : IInspectable
+    {
+        HRESULT IsSupported([in] Microsoft.Graphics.Canvas.CanvasDevice* device, [out, retval] boolean* result);
+    }
+
+    [STANDARD_ATTRIBUTES, activatable(VERSION), static(IWhiteLevelAdjustmentEffectStatics, VERSION)]
+    runtimeclass WhiteLevelAdjustmentEffect
+    {
+        [default] interface IWhiteLevelAdjustmentEffect;
+    }
+}
+
+#endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.abi.idl
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.abi.idl
@@ -37,7 +37,7 @@ namespace Microsoft.Graphics.Canvas.Effects
     [version(VERSION), uuid(58DACBF8-637A-5DA7-9457-1EEEDF5A191C), exclusiveto(WhiteLevelAdjustmentEffect)]
     interface IWhiteLevelAdjustmentEffectStatics : IInspectable
     {
-        HRESULT IsSupported([in] Microsoft.Graphics.Canvas.CanvasDevice* device, [out, retval] boolean* result);
+        [propget] HRESULT IsSupported([out, retval] boolean* value);
     }
 
     [STANDARD_ATTRIBUTES, activatable(VERSION), static(IWhiteLevelAdjustmentEffectStatics, VERSION)]

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.cpp
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.cpp
@@ -14,6 +14,9 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     WhiteLevelAdjustmentEffect::WhiteLevelAdjustmentEffect(ICanvasDevice* device, ID2D1Effect* effect)
         : CanvasEffect(EffectId(), 2, 1, true, device, effect, static_cast<IWhiteLevelAdjustmentEffect*>(this))
     {
+        if (!SharedDeviceState::GetInstance()->IsEffectRegistered(WhiteLevelAdjustmentEffect::EffectId(), true))
+            ThrowHR(E_NOTIMPL, Strings::NotSupportedOnThisVersionOfWindows);
+
         if (!effect)
         {
             // Set default values
@@ -53,13 +56,12 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         });
     }
 
-    IFACEMETHODIMP WhiteLevelAdjustmentEffectFactory::IsSupported(ICanvasDevice* device, boolean* result)
+    IFACEMETHODIMP WhiteLevelAdjustmentEffectFactory::get_IsSupported(_Out_ boolean* result)
     {
         return ExceptionBoundary([&]
         {
-            CheckInPointer(device);
             CheckInPointer(result);
-            *result = SharedDeviceState::GetInstance()->IsEffectSupportedWithAnyDevice(device, WhiteLevelAdjustmentEffect::EffectId(), L"Win10_17763");
+            *result = SharedDeviceState::GetInstance()->IsEffectRegistered(WhiteLevelAdjustmentEffect::EffectId(), true);
         });
     }
 

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.cpp
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// This file was automatically generated. Please do not edit it manually.
+
+#include "pch.h"
+#include "WhiteLevelAdjustmentEffect.h"
+
+#if (defined _WIN32_WINNT_WIN10) && (WINVER >= _WIN32_WINNT_WIN10)
+
+namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { namespace Effects
+{
+    WhiteLevelAdjustmentEffect::WhiteLevelAdjustmentEffect(ICanvasDevice* device, ID2D1Effect* effect)
+        : CanvasEffect(EffectId(), 2, 1, true, device, effect, static_cast<IWhiteLevelAdjustmentEffect*>(this))
+    {
+        if (!effect)
+        {
+            // Set default values
+            SetBoxedProperty<float>(D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL, 80.0f);
+            SetBoxedProperty<float>(D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL, 80.0f);
+        }
+    }
+
+    IMPLEMENT_EFFECT_PROPERTY(WhiteLevelAdjustmentEffect,
+        InputWhiteLevel,
+        float,
+        float,
+        D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL)
+
+    IMPLEMENT_EFFECT_PROPERTY(WhiteLevelAdjustmentEffect,
+        OutputWhiteLevel,
+        float,
+        float,
+        D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL)
+
+    IMPLEMENT_EFFECT_SOURCE_PROPERTY(WhiteLevelAdjustmentEffect,
+        Source,
+        0)
+
+    IMPLEMENT_EFFECT_PROPERTY_MAPPING(WhiteLevelAdjustmentEffect,
+        { L"InputWhiteLevel",  D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL,  GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT },
+        { L"OutputWhiteLevel", D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL, GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT })
+
+    IFACEMETHODIMP WhiteLevelAdjustmentEffectFactory::ActivateInstance(IInspectable** instance)
+    {
+        return ExceptionBoundary([&]
+        {
+            auto effect = Make<WhiteLevelAdjustmentEffect>();
+            CheckMakeResult(effect);
+
+            ThrowIfFailed(effect.CopyTo(instance));
+        });
+    }
+
+    IFACEMETHODIMP WhiteLevelAdjustmentEffectFactory::IsSupported(ICanvasDevice* device, boolean* result)
+    {
+        return ExceptionBoundary([&]
+        {
+            CheckInPointer(device);
+            CheckInPointer(result);
+            *result = SharedDeviceState::GetInstance()->IsEffectSupportedOnAnyDevice(device, WhiteLevelAdjustmentEffect::EffectId(), L"Win10_17763");
+        });
+    }
+
+    ActivatableClassWithFactory(WhiteLevelAdjustmentEffect, WhiteLevelAdjustmentEffectFactory);
+}}}}}
+
+#endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.cpp
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.cpp
@@ -59,7 +59,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         {
             CheckInPointer(device);
             CheckInPointer(result);
-            *result = SharedDeviceState::GetInstance()->IsEffectSupportedOnAnyDevice(device, WhiteLevelAdjustmentEffect::EffectId(), L"Win10_17763");
+            *result = SharedDeviceState::GetInstance()->IsEffectSupportedWithAnyDevice(device, WhiteLevelAdjustmentEffect::EffectId(), L"Win10_17763");
         });
     }
 

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.h
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.h
@@ -40,7 +40,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
 
     public:
         IFACEMETHODIMP ActivateInstance(IInspectable**) override;
-        IFACEMETHOD(IsSupported)(ICanvasDevice* device, boolean* result) override;
+        IFACEMETHOD(get_IsSupported)(boolean* value) override;
     };
 }}}}}
 

--- a/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.h
+++ b/winrt/lib/effects/generated/WhiteLevelAdjustmentEffect.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// This file was automatically generated. Please do not edit it manually.
+
+#pragma once
+
+#if (defined _WIN32_WINNT_WIN10) && (WINVER >= _WIN32_WINNT_WIN10)
+
+namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { namespace Effects 
+{
+    using namespace ::Microsoft::WRL;
+    using namespace ABI::Microsoft::Graphics::Canvas;
+
+    class WhiteLevelAdjustmentEffect : public RuntimeClass<
+        IWhiteLevelAdjustmentEffect,
+        MixIn<WhiteLevelAdjustmentEffect, CanvasEffect>>,
+        public CanvasEffect
+    {
+        InspectableClass(RuntimeClass_Microsoft_Graphics_Canvas_Effects_WhiteLevelAdjustmentEffect, BaseTrust);
+
+    public:
+        WhiteLevelAdjustmentEffect(ICanvasDevice* device = nullptr, ID2D1Effect* effect = nullptr);
+
+        static IID const& EffectId() { return CLSID_D2D1WhiteLevelAdjustment; }
+
+        EFFECT_PROPERTY(InputWhiteLevel, float);
+        EFFECT_PROPERTY(OutputWhiteLevel, float);
+        EFFECT_PROPERTY(Source, IGraphicsEffectSource*);
+
+        EFFECT_PROPERTY_MAPPING();
+    };
+
+    class WhiteLevelAdjustmentEffectFactory
+        : public AgileActivationFactory<IWhiteLevelAdjustmentEffectStatics>
+        , private LifespanTracker<WhiteLevelAdjustmentEffectFactory>
+    {
+        InspectableClassStatic(RuntimeClass_Microsoft_Graphics_Canvas_Effects_WhiteLevelAdjustmentEffect, BaseTrust);
+
+    public:
+        IFACEMETHODIMP ActivateInstance(IInspectable**) override;
+        IFACEMETHOD(IsSupported)(ICanvasDevice* device, boolean* result) override;
+    };
+}}}}}
+
+#endif // _WIN32_WINNT_WIN10

--- a/winrt/lib/utils/GuidUtilities.h
+++ b/winrt/lib/utils/GuidUtilities.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+#pragma once
+
+namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
+{
+
+    struct GuidComparer {
+        bool operator()(GUID const& left, GUID const& right) const {
+            return memcmp(&left, &right, sizeof(GUID)) < 0;
+        }
+    };
+
+}}}}

--- a/winrt/lib/winrt.lib.uap.vcxproj
+++ b/winrt/lib/winrt.lib.uap.vcxproj
@@ -88,6 +88,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\EmbossEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\ExposureEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HueToRgbEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\InvertEffect.h" />
@@ -248,6 +249,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\EmbossEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\ExposureEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HueToRgbEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\InvertEffect.cpp" />
@@ -437,6 +439,7 @@
     <None Include="$(MSBuildThisFileDirectory)effects\generated\EmbossEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\ExposureEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.abi.idl" />
+    <None Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\HueToRgbEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\InvertEffect.abi.idl" />

--- a/winrt/lib/winrt.lib.uap.vcxproj
+++ b/winrt/lib/winrt.lib.uap.vcxproj
@@ -54,7 +54,8 @@
     </ItemGroup>
     <ItemGroup Condition="'$(UseNuGetSDK)' != ''">
       <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\3.0.0.0" />
-      <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\031\6.0.0.0" /> <!-- Windows.Foundation.UniversalApiContract lives here -->
+      <MetaDataDir Include="$(WindowsSDK_MetadataPath)\$(TargetPlatformVersion)\031\6.0.0.0" />
+      <!-- Windows.Foundation.UniversalApiContract lives here -->
     </ItemGroup>
     <Exec Command="$(MdMergeExe) -v @(MetaDataDir -> '-metadata_dir &quot;%(Identity)&quot;', ' ') -o &quot;$(MergedWinmdDirectory)&quot; -i &quot;$(UnmergedWinmdDirectory)&quot; -partial -n:Microsoft.Graphics.Canvas:3" />
   </Target>
@@ -97,6 +98,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\StraightenEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\TemperatureAndTintEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\VignetteEffect.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\WhiteLevelAdjustmentEffect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)geometry\InkToGeometryCommandSink.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)images\WicAdapter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)pch.h" />
@@ -256,6 +258,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\StraightenEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\TemperatureAndTintEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\VignetteEffect.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\WhiteLevelAdjustmentEffect.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -444,6 +447,7 @@
     <None Include="$(MSBuildThisFileDirectory)effects\generated\StraightenEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\TemperatureAndTintEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)effects\generated\VignetteEffect.abi.idl" />
+    <None Include="$(MSBuildThisFileDirectory)effects\generated\WhiteLevelAdjustmentEffect.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)geometry\CanvasCachedGeometry.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)geometry\CanvasGeometry.abi.idl" />
     <None Include="$(MSBuildThisFileDirectory)geometry\CanvasPathBuilder.abi.idl" />

--- a/winrt/lib/winrt.lib.uap.vcxproj
+++ b/winrt/lib/winrt.lib.uap.vcxproj
@@ -221,6 +221,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\Conversion.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\D2DResourceLock.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\DxgiUtilities.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)utils\GuidUtilities.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\ResourceManager.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\ResourceWrapper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\Strings.h" />

--- a/winrt/lib/winrt.lib.uap.vcxproj.filters
+++ b/winrt/lib/winrt.lib.uap.vcxproj.filters
@@ -349,6 +349,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\VignetteEffect.cpp">
       <Filter>effects\generated</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\WhiteLevelAdjustmentEffect.cpp">
+      <Filter>effects\generated</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)xaml\CanvasVirtualImageSource.cpp">
       <Filter>xaml</Filter>
     </ClCompile>
@@ -814,6 +817,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\VignetteEffect.h">
       <Filter>effects\generated</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\WhiteLevelAdjustmentEffect.h">
+      <Filter>effects\generated</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)xaml\CanvasVirtualImageSource.h">
       <Filter>xaml</Filter>
     </ClInclude>
@@ -1145,6 +1151,9 @@
       <Filter>effects\generated</Filter>
     </None>
     <None Include="$(MSBuildThisFileDirectory)effects\generated\VignetteEffect.abi.idl">
+      <Filter>effects\generated</Filter>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)effects\generated\WhiteLevelAdjustmentEffect.abi.idl">
       <Filter>effects\generated</Filter>
     </None>
     <None Include="$(MSBuildThisFileDirectory)geometry\CanvasCachedGeometry.abi.idl">

--- a/winrt/lib/winrt.lib.uap.vcxproj.filters
+++ b/winrt/lib/winrt.lib.uap.vcxproj.filters
@@ -319,7 +319,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.cpp">
       <Filter>effects\generated</Filter>
     </ClCompile>
-        <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.cpp">
+    <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.cpp">
       <Filter>effects\generated</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.cpp">
@@ -790,7 +790,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.h">
       <Filter>effects\generated</Filter>
     </ClInclude>
-        <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.h">
+    <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.h">
       <Filter>effects\generated</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.h">
@@ -954,6 +954,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)svg\CanvasSvgStrokeDashArrayAttribute.h">
       <Filter>svg</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)utils\GuidUtilities.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/winrt/lib/winrt.lib.uap.vcxproj.filters
+++ b/winrt/lib/winrt.lib.uap.vcxproj.filters
@@ -319,6 +319,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.cpp">
       <Filter>effects\generated</Filter>
     </ClCompile>
+        <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.cpp">
+      <Filter>effects\generated</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.cpp">
       <Filter>effects\generated</Filter>
     </ClCompile>
@@ -787,6 +790,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.h">
       <Filter>effects\generated</Filter>
     </ClInclude>
+        <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.h">
+      <Filter>effects\generated</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.h">
       <Filter>effects\generated</Filter>
     </ClInclude>
@@ -1121,6 +1127,9 @@
       <Filter>effects\generated</Filter>
     </None>
     <None Include="$(MSBuildThisFileDirectory)effects\generated\GrayscaleEffect.abi.idl">
+      <Filter>effects\generated</Filter>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)effects\generated\HdrToneMapEffect.abi.idl">
       <Filter>effects\generated</Filter>
     </None>
     <None Include="$(MSBuildThisFileDirectory)effects\generated\HighlightsAndShadowsEffect.abi.idl">


### PR DESCRIPTION
This is my initial attempt to add the HDR tone map and white level adjustment effects. The main question is how to do the is effect supported check. What I've done is done a check that tries to create the effect and caches the result. It actually takes a key so that the cached result can apply to more than one effect. I check for an `E_NOT_SET` result to indicate the effect is missing. According to my tests this is the result returned if there is no such effect. I'd appreciate some feedback from @shawnhar as to whether this is the correct thing to do or whether the approach is good in general, especially as I will be using this in my own project anyway regardless of whether this pull request gets accepted.

The other minor thing I was unsure about is the file `UpdateApiResourceFiles.cmd`. I think I probably should have added the new effects to the `FILE_LIST` in here, but I didn't really understand what this file did and have no way of verifying it.