### PR TITLE
Change last seen parent to weak ref

### DIFF
--- a/winrt/lib/xaml/BaseControl.h
+++ b/winrt/lib/xaml/BaseControl.h
@@ -134,7 +134,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
 
         RenderTarget m_currentRenderTarget;
 
-        ComPtr<IDependencyObject> m_lastSeenParent;
+        WeakRef m_lastSeenParent;
 
         ComPtr<ICanvasDevice> m_customDevice;
 
@@ -233,7 +233,10 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
             return ExceptionBoundary(
                 [&]
                 {
-                    RemoveFromVisualTreeImpl(m_lastSeenParent.Get(), As<IUIElement>(GetControl()).Get());
+                    if (!m_lastSeenParent) {
+                        return;
+                    }
+                    RemoveFromVisualTreeImpl(LockWeakRef<IDependencyObject>(m_lastSeenParent).Get(), As<IUIElement>(GetControl()).Get());
                 });
         }
 
@@ -913,7 +916,13 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
 
         void UpdateLastSeenParent()
         {
-            As<IFrameworkElement>(GetControl()->GetComposableBase())->get_Parent(&m_lastSeenParent);
+            ComPtr<IDependencyObject> parent;
+            As<IFrameworkElement>(GetControl()->GetComposableBase())->get_Parent(&parent);
+            if (!parent) {
+                m_lastSeenParent.Reset();
+                return;
+            }
+            m_lastSeenParent = AsWeak(parent.Get());
         }
 
         HRESULT OnUnloaded(IInspectable*, IRoutedEventArgs*)

--- a/winrt/lib/xaml/CanvasSwapChainPanel.cpp
+++ b/winrt/lib/xaml/CanvasSwapChainPanel.cpp
@@ -88,7 +88,13 @@ HRESULT CanvasSwapChainPanel::OnLoaded(IInspectable*, IRoutedEventArgs*)
     return ExceptionBoundary(
         [&]
         {
-            As<IFrameworkElement>(GetComposableBase())->get_Parent(&m_lastSeenParent);
+            ComPtr<IDependencyObject> parent;
+            As<IFrameworkElement>(GetComposableBase())->get_Parent(&parent);
+            if (!parent) {
+                m_lastSeenParent.Reset();
+                return;
+            }
+            m_lastSeenParent = AsWeak(parent.Get());
         });
 }
 
@@ -130,7 +136,10 @@ IFACEMETHODIMP CanvasSwapChainPanel::RemoveFromVisualTree()
     return ExceptionBoundary(
         [&]
         {
-            RemoveFromVisualTreeImpl(m_lastSeenParent.Get(), As<IUIElement>(this).Get());
+            if (!m_lastSeenParent) {
+                return;
+            }
+            RemoveFromVisualTreeImpl(LockWeakRef<IDependencyObject>(m_lastSeenParent).Get(), As<IUIElement>(this).Get());
         });
 }
 

--- a/winrt/lib/xaml/CanvasSwapChainPanel.h
+++ b/winrt/lib/xaml/CanvasSwapChainPanel.h
@@ -39,7 +39,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         std::shared_ptr<ICanvasSwapChainPanelAdapter> m_adapter;
 
         ComPtr<ICanvasSwapChain> m_canvasSwapChain;
-        ComPtr<IDependencyObject> m_lastSeenParent;
+        WeakRef m_lastSeenParent;
 
     public:
         CanvasSwapChainPanel(std::shared_ptr<ICanvasSwapChainPanelAdapter> adapter);


### PR DESCRIPTION
As discussed in issue <https://github.com/microsoft/Win2D/issues/799>.

One question - if the parent is null in UpdateLastSeenParent, should we keep the old parent weak reference? At the moment I'm resetting it since that is the same as the current behavior. ie. should I remove the line `m_lastSeenParent.Reset();`?