### PR TITLE
Add thread safety to WIC initialization using call_once

### DIFF
--- a/winrt/lib/images/CanvasBitmap.cpp
+++ b/winrt/lib/images/CanvasBitmap.cpp
@@ -272,8 +272,9 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
 
     WicBitmapSource DefaultBitmapAdapter::CreateWicBitmapSource(ICanvasDevice* device, IStream* fileStream, bool tryEnableIndexing)
     {
+        auto factory = m_wicAdapter->GetFactory();
         ComPtr<IWICBitmapDecoder> wicBitmapDecoder;
-        ThrowIfFailed(m_wicAdapter->GetFactory()->CreateDecoderFromStream(
+        ThrowIfFailed(factory->CreateDecoderFromStream(
             fileStream,
             nullptr,
             WICDecodeMetadataCacheOnDemand,
@@ -310,7 +311,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         auto transformOptions = GetTransformOptionsFromPhotoOrientation(orientation);
 
         ComPtr<IWICFormatConverter> wicFormatConverter;
-        ThrowIfFailed(m_wicAdapter->GetFactory()->CreateFormatConverter(&wicFormatConverter));
+        ThrowIfFailed(factory->CreateFormatConverter(&wicFormatConverter));
 
         auto targetPixelFormat = GUID_WICPixelFormat32bppPBGRA;
 

--- a/winrt/lib/images/CanvasImage.cpp
+++ b/winrt/lib/images/CanvasImage.cpp
@@ -406,12 +406,11 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
 
     ComPtr<IWICImagingFactory2> const& DefaultCanvasImageAdapter::GetFactory()
     {
-        if (!m_wicAdapter)
-        {
+        std::call_once(m_initWicAdapterFlag, [this] {
             // Hold on to the wic adapter so it doesn't keep getting destroyed
             // and recreated.
             m_wicAdapter = WicAdapter::GetInstance();
-        }
+        });
 
         return m_wicAdapter->GetFactory();
     }

--- a/winrt/lib/images/CanvasImage.h
+++ b/winrt/lib/images/CanvasImage.h
@@ -94,6 +94,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     class DefaultCanvasImageAdapter : public CanvasImageAdapter
     {
         std::shared_ptr<WicAdapter> m_wicAdapter;
+        std::once_flag m_initWicAdapterFlag;
         
     public:
         virtual ComPtr<IAsyncAction> RunAsync(std::function<void()>&& fn) override;

--- a/winrt/lib/images/WicAdapter.h
+++ b/winrt/lib/images/WicAdapter.h
@@ -21,6 +21,7 @@ public:
 class DefaultWicAdapter : public WicAdapter
 {
     ComPtr<IWICImagingFactory2> m_wicFactory;
+    std::once_flag m_initFactoryFlag;
 
 public:
     DefaultWicAdapter()
@@ -29,15 +30,14 @@ public:
 
     virtual ComPtr<IWICImagingFactory2> const& GetFactory() override
     {
-        if (!m_wicFactory)
-        {
+        std::call_once(m_initFactoryFlag, [this] {
             ThrowIfFailed(
                 CoCreateInstance(
                     CLSID_WICImagingFactory,
                     nullptr,
                     CLSCTX_INPROC_SERVER,
-                    IID_PPV_ARGS(&m_wicFactory)));        
-        }
+                    IID_PPV_ARGS(&m_wicFactory)));
+        });
 
         return m_wicFactory;
     }


### PR DESCRIPTION
Technically the singleton DefaultWicAdapter instance was not thread-safe when creating the WIC factory. Similarly, the DefaultCanvasImageAdapter was not thread-safe when storing a copy of the WicAdapter instance. In the second case in practice it probably was thread-safe anyway assuming setting a pointer is atomic. In the first case it would probably have been very difficult to hit a serious issue, although potentially it could have leaked the factory object and potentially returned a different instance on different calls.

This pull request fixes that by using std::call_once.