### PR TITLE
Update README.md with link to DX Landing Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ rendering with GPU acceleration. It is available to C#, C++ and VB developers
 writing apps for the Windows Universal Platform (UWP). It utilizes the power
 of Direct2D, and integrates seamlessly with XAML and CoreWindow.
 
+Visit the [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/) for more resources for DirectX developers.
+
 ##### Where to get it
 - [NuGet package](http://www.nuget.org/packages/Win2D.uwp)
 - [Source code](http://github.com/Microsoft/Win2D)


### PR DESCRIPTION
Added link to the DirectX Landing Page at the top of this readme to make sure all DX-related components link back to our new single source of truth.