### PR TITLE
Enable fully custom Win2D effects: new ICanvasImageInterop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ rendering with GPU acceleration. It is available to C#, C++ and VB developers
 writing apps for the Windows Universal Platform (UWP). It utilizes the power
 of Direct2D, and integrates seamlessly with XAML and CoreWindow.
 
+Visit the [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/) for more resources for DirectX developers.
+
 ##### Where to get it
 - [NuGet package](http://www.nuget.org/packages/Win2D.uwp)
 - [Source code](http://github.com/Microsoft/Win2D)

--- a/build/Win2D.cpp.props
+++ b/build/Win2D.cpp.props
@@ -13,6 +13,10 @@
 
   <Import Project="Win2D.common.props" />
 
+  <Target Name="CleanIntermediateFiles" AfterTargets="Build" Condition="'$(AzurePipeline)'!=''">
+    <RemoveDir Directories="$(IntDir)" />
+  </Target>
+
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM" Condition="'$(ApplicationType)' != ''">
       <Configuration>Debug</Configuration>

--- a/build/Win2D.cs.props
+++ b/build/Win2D.cs.props
@@ -23,4 +23,8 @@
   <PropertyGroup Condition="'$(Platform)' == 'ARM64'">
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
   </PropertyGroup>
+
+  <Target Name="CleanIntermediateFiles" AfterTargets="Build" Condition="'$(AzurePipeline)'!=''">
+    <RemoveDir Directories="$(IntDir)" />
+  </Target>
 </Project>

--- a/build/clear-space.cmd
+++ b/build/clear-space.cmd
@@ -1,0 +1,5 @@
+dir /s
+
+del /f /s /q build\pkges
+del /f /s /q obj
+del /f /s /q .git

--- a/winrt/dll/winrt.dll.uap.vcxproj
+++ b/winrt/dll/winrt.dll.uap.vcxproj
@@ -37,6 +37,7 @@
       <AdditionalIncludeDirectories>$(EtwDirectory);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAsWinRT>false</CompileAsWinRT>
       <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -89,5 +90,5 @@
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="..\..\build\Win2D.cpp.targets" />
-
+  
 </Project>

--- a/winrt/lib/brushes/CanvasImageBrush.cpp
+++ b/winrt/lib/brushes/CanvasImageBrush.cpp
@@ -118,7 +118,7 @@ void CanvasImageBrush::SetImage(ICanvasImage* image)
     else
     {
         // Use an image brush.
-        auto d2dImage = As<ICanvasImageInternal>(image)->GetD2DImage(m_device.EnsureNotClosed().Get(), nullptr, GetImageFlags::MinimalRealization);
+        auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, m_device.EnsureNotClosed().Get(), nullptr, GetImageFlags::MinimalRealization);
 
         if (m_d2dImageBrush)
         {

--- a/winrt/lib/brushes/CanvasImageBrush.cpp
+++ b/winrt/lib/brushes/CanvasImageBrush.cpp
@@ -118,7 +118,7 @@ void CanvasImageBrush::SetImage(ICanvasImage* image)
     else
     {
         // Use an image brush.
-        auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, m_device.EnsureNotClosed().Get(), nullptr, GetD2DImageFlags::MinimalRealization);
+        auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, m_device.EnsureNotClosed().Get(), nullptr, WIN2D_GET_D2D_IMAGE_FLAGS_MINIMAL_REALIZATION);
 
         if (m_d2dImageBrush)
         {
@@ -397,8 +397,9 @@ ComPtr<ID2D1Brush> CanvasImageBrush::GetD2DBrush(ID2D1DeviceContext* deviceConte
         // If our input image is an effect graph, make sure it is fully configured to match the target DPI.
         if (deviceContext)
         {
-            GetD2DImageFlags effectFlags = ((flags & GetBrushFlags::AlwaysInsertDpiCompensation) != GetBrushFlags::None) ? GetD2DImageFlags::AlwaysInsertDpiCompensation
-                                                                                                                         : GetD2DImageFlags::ReadDpiFromDeviceContext;
+            WIN2D_GET_D2D_IMAGE_FLAGS effectFlags = ((flags & GetBrushFlags::AlwaysInsertDpiCompensation) != GetBrushFlags::None)
+                ? WIN2D_GET_D2D_IMAGE_FLAGS_ALWAYS_INSERT_DPI_COMPENSATION
+                : WIN2D_GET_D2D_IMAGE_FLAGS_READ_DPI_FROM_DEVICE_CONTEXT;
 
             RealizeSourceEffect(deviceContext, effectFlags, 0);
         }
@@ -429,10 +430,10 @@ IFACEMETHODIMP CanvasImageBrush::GetNativeResource(ICanvasDevice* device, float 
             else
             {
                 // If our input image is an effect graph, make sure it is fully configured to match the target DPI.
-                GetD2DImageFlags effectFlags = GetD2DImageFlags::AllowNullEffectInputs;
+                WIN2D_GET_D2D_IMAGE_FLAGS effectFlags = WIN2D_GET_D2D_IMAGE_FLAGS_ALLOW_NULL_EFFECT_INPUTS;
 
                 if (dpi <= 0)
-                    effectFlags |= GetD2DImageFlags::AlwaysInsertDpiCompensation;
+                    effectFlags |= WIN2D_GET_D2D_IMAGE_FLAGS_ALWAYS_INSERT_DPI_COMPENSATION;
 
                 RealizeSourceEffect(nullptr, effectFlags, dpi);
 
@@ -441,7 +442,7 @@ IFACEMETHODIMP CanvasImageBrush::GetNativeResource(ICanvasDevice* device, float 
         });
 }
 
-void CanvasImageBrush::RealizeSourceEffect(ID2D1DeviceContext* deviceContext, GetD2DImageFlags flags, float dpi)
+void CanvasImageBrush::RealizeSourceEffect(ID2D1DeviceContext* deviceContext, WIN2D_GET_D2D_IMAGE_FLAGS flags, float dpi)
 {
     // Do we have a source image?
     ComPtr<ID2D1Image> d2dImage;

--- a/winrt/lib/brushes/CanvasImageBrush.cpp
+++ b/winrt/lib/brushes/CanvasImageBrush.cpp
@@ -118,7 +118,7 @@ void CanvasImageBrush::SetImage(ICanvasImage* image)
     else
     {
         // Use an image brush.
-        auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, m_device.EnsureNotClosed().Get(), nullptr, GetImageFlags::MinimalRealization);
+        auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, m_device.EnsureNotClosed().Get(), nullptr, GetD2DImageFlags::MinimalRealization);
 
         if (m_d2dImageBrush)
         {
@@ -397,8 +397,8 @@ ComPtr<ID2D1Brush> CanvasImageBrush::GetD2DBrush(ID2D1DeviceContext* deviceConte
         // If our input image is an effect graph, make sure it is fully configured to match the target DPI.
         if (deviceContext)
         {
-            GetImageFlags effectFlags = ((flags & GetBrushFlags::AlwaysInsertDpiCompensation) != GetBrushFlags::None) ? GetImageFlags::AlwaysInsertDpiCompensation
-                                                                                                                      : GetImageFlags::ReadDpiFromDeviceContext;
+            GetD2DImageFlags effectFlags = ((flags & GetBrushFlags::AlwaysInsertDpiCompensation) != GetBrushFlags::None) ? GetD2DImageFlags::AlwaysInsertDpiCompensation
+                                                                                                                         : GetD2DImageFlags::ReadDpiFromDeviceContext;
 
             RealizeSourceEffect(deviceContext, effectFlags, 0);
         }
@@ -429,10 +429,10 @@ IFACEMETHODIMP CanvasImageBrush::GetNativeResource(ICanvasDevice* device, float 
             else
             {
                 // If our input image is an effect graph, make sure it is fully configured to match the target DPI.
-                GetImageFlags effectFlags = GetImageFlags::AllowNullEffectInputs;
+                GetD2DImageFlags effectFlags = GetD2DImageFlags::AllowNullEffectInputs;
 
                 if (dpi <= 0)
-                    effectFlags |= GetImageFlags::AlwaysInsertDpiCompensation;
+                    effectFlags |= GetD2DImageFlags::AlwaysInsertDpiCompensation;
 
                 RealizeSourceEffect(nullptr, effectFlags, dpi);
 
@@ -441,7 +441,7 @@ IFACEMETHODIMP CanvasImageBrush::GetNativeResource(ICanvasDevice* device, float 
         });
 }
 
-void CanvasImageBrush::RealizeSourceEffect(ID2D1DeviceContext* deviceContext, GetImageFlags flags, float dpi)
+void CanvasImageBrush::RealizeSourceEffect(ID2D1DeviceContext* deviceContext, GetD2DImageFlags flags, float dpi)
 {
     // Do we have a source image?
     ComPtr<ID2D1Image> d2dImage;

--- a/winrt/lib/brushes/CanvasImageBrush.h
+++ b/winrt/lib/brushes/CanvasImageBrush.h
@@ -98,7 +98,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         void SwitchToImageBrush(ID2D1Image* image);
         void SwitchToBitmapBrush(ID2D1Bitmap1* bitmap);
         void TrySwitchFromImageBrushToBitmapBrush();
-        void RealizeSourceEffect(ID2D1DeviceContext* deviceContext, GetD2DImageFlags flags, float dpi);
+        void RealizeSourceEffect(ID2D1DeviceContext* deviceContext, WIN2D_GET_D2D_IMAGE_FLAGS flags, float dpi);
     };
 
 }}}}}

--- a/winrt/lib/brushes/CanvasImageBrush.h
+++ b/winrt/lib/brushes/CanvasImageBrush.h
@@ -98,7 +98,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         void SwitchToImageBrush(ID2D1Image* image);
         void SwitchToBitmapBrush(ID2D1Bitmap1* bitmap);
         void TrySwitchFromImageBrushToBitmapBrush();
-        void RealizeSourceEffect(ID2D1DeviceContext* deviceContext, GetImageFlags flags, float dpi);
+        void RealizeSourceEffect(ID2D1DeviceContext* deviceContext, GetD2DImageFlags flags, float dpi);
     };
 
 }}}}}

--- a/winrt/lib/drawing/CanvasDrawingSession.cpp
+++ b/winrt/lib/drawing/CanvasDrawingSession.cpp
@@ -489,7 +489,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                     // If the image is not an ICanvasImageInternal, it must be an ICanvasImageInterop.
                     auto imageInterop = As<ICanvasImageInterop>(image);
 
-                    ThrowIfFailed(imageInterop->GetOrCreateD2DImage(m_canvasDevice, m_deviceContext, CanvasImageGetD2DImageFlags::ReadDpiFromDeviceContext, 0, nullptr, d2dImage.GetAddressOf()));
+                    ThrowIfFailed(imageInterop->GetD2DImage(m_canvasDevice, m_deviceContext, CanvasImageGetD2DImageFlags::ReadDpiFromDeviceContext, 0, nullptr, d2dImage.GetAddressOf()));
                 }
 
                 auto d2dInterpolationMode = static_cast<D2D1_INTERPOLATION_MODE>(m_interpolation);

--- a/winrt/lib/drawing/CanvasDrawingSession.cpp
+++ b/winrt/lib/drawing/CanvasDrawingSession.cpp
@@ -471,26 +471,8 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             else
             {
                 // If DrawBitmap cannot handle this request, we must use the DrawImage slow path.
-                // There are two possible cases for the input image being drawn:
-                //   - It is one of the built-in Win2D effects, so it will implement ICanvasImageInternal.
-                //   - It is a custom Win2D-compatible effect, so it will implement ICanvasImageInterop.
 
-                ComPtr<ID2D1Image> d2dImage;
-
-                auto internalImage = MaybeAs<ICanvasImageInternal>(image);
-
-                // Try to get an ICanvasImageInternal first (this is the most common path).
-                if (internalImage)
-                {
-                    d2dImage = internalImage->GetD2DImage(m_canvasDevice, m_deviceContext);
-                }
-                else
-                {
-                    // If the image is not an ICanvasImageInternal, it must be an ICanvasImageInterop.
-                    auto imageInterop = As<ICanvasImageInterop>(image);
-
-                    ThrowIfFailed(imageInterop->GetD2DImage(m_canvasDevice, m_deviceContext, CanvasImageGetD2DImageFlags::ReadDpiFromDeviceContext, 0, nullptr, d2dImage.GetAddressOf()));
-                }
+                ComPtr<ID2D1Image> d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, m_canvasDevice, m_deviceContext);
 
                 auto d2dInterpolationMode = static_cast<D2D1_INTERPOLATION_MODE>(m_interpolation);
                 auto d2dCompositeMode = composite ? static_cast<D2D1_COMPOSITE_MODE>(*composite)

--- a/winrt/lib/effects/CanvasEffect.cpp
+++ b/winrt/lib/effects/CanvasEffect.cpp
@@ -106,6 +106,20 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         return GetImageBoundsImpl(this, resourceCreator, &transform, bounds);
     }
 
+    //
+    // ICanvasImageInterop
+    //
+
+    IFACEMETHODIMP CanvasEffect::GetDevice(ICanvasDevice** device)
+    {
+        return ExceptionBoundary([&]
+            {
+                ThrowIfClosed();
+                CheckAndClearOutPointer(device);
+
+                *device = RealizationDevice();
+            });
+    }
 
     //
     // ICanvasImageInternal

--- a/winrt/lib/effects/CanvasEffect.cpp
+++ b/winrt/lib/effects/CanvasEffect.cpp
@@ -117,7 +117,15 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
                 ThrowIfClosed();
                 CheckAndClearOutPointer(device);
 
-                *device = RealizationDevice();
+                auto realizationDevice = RealizationDevice();
+
+                // RealizationDevice() returns an ICanvasDevice* (not a ComPtr<ICanvasDevice>), so we can
+                // just check if it's not null and forward to QueryInterface if that's the case. If instead
+                // the device is null, CheckAndClearOutPointer will have already set the argument to null.
+                if (realizationDevice)
+                {
+                    ThrowIfFailed(realizationDevice->QueryInterface(IID_PPV_ARGS(device)));
+                }
             });
     }
 

--- a/winrt/lib/effects/CanvasEffect.cpp
+++ b/winrt/lib/effects/CanvasEffect.cpp
@@ -1079,7 +1079,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
             else if (interopSource)
             {
                 // Otherwise, if the source is an ICanvasImageInterop, get the device from there. This will
-                // either be the previous one that was passed to ICanvasImageInterop::GetOrCreateD2DImage, or null.
+                // either be the previous one that was passed to ICanvasImageInterop::GetD2DImage, or null.
                 ThrowIfFailed(interopSource->GetDevice(&sourceDevice));
             }
 
@@ -1108,7 +1108,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
                 // HRESULTs are used by default to propagate errors, and exceptions are never thrown. As such, that flag has no meaning.
                 CanvasImageGetD2DImageFlags interopFlags = static_cast<CanvasImageGetD2DImageFlags>(flags & ~GetImageFlags::UnrealizeOnFailure);
 
-                hr = interopSource->GetOrCreateD2DImage(RealizationDevice(), deviceContext, interopFlags, targetDpi, &realizedDpi, &realizedSource);
+                hr = interopSource->GetD2DImage(RealizationDevice(), deviceContext, interopFlags, targetDpi, &realizedDpi, &realizedSource);
 
                 // To match the behavior of ICanvasImageInternal::GetD2DImage in case of failure, check if the flags being used did have the
                 // GetImageFlags::UnrealizeOnFailure set. If not, and the call failed, then we explicitly throw from the returned HRESULT.

--- a/winrt/lib/effects/CanvasEffect.cpp
+++ b/winrt/lib/effects/CanvasEffect.cpp
@@ -1007,9 +1007,37 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
             }
             else
             {
-                // Get the underlying D2D interface. This call recurses through the effect graph.
                 float realizedDpi;
-                auto realizedSource = As<ICanvasImageInternal>(source)->GetD2DImage(RealizationDevice(), deviceContext, flags, targetDpi, &realizedDpi);
+
+                // Get the underlying D2D interface. This call recurses through the effect graph. Just like
+                // when setting an effect, the input can be either ICanvasImageInternal or ICanvasImageInterop.
+                // Query for ICanvasImageInternal as that's the most common scenario (just like in SetD2DInput).
+                ComPtr<ID2D1Image> realizedSource;
+                ComPtr<ICanvasImageInternal> internalSource;
+
+                HRESULT hr = source->QueryInterface(IID_PPV_ARGS(&internalSource));
+
+                // If QueryInterface failed in any way other than E_NOINTERFACE, we just rethrow (just like in SetD2DInput).
+                if (FAILED(hr) && hr != E_NOINTERFACE)
+                    ThrowHR(hr);
+
+                // If the input was indeed an ICanvasImageInternal, invoke its GetD2DImage method normally.
+                if (SUCCEEDED(hr))
+                {
+                    realizedSource = internalSource->GetD2DImage(RealizationDevice(), deviceContext, flags, targetDpi, &realizedDpi);
+                }
+                else
+                {
+                    // Strip the UnrealizeOnFailure flag for the COM call, as it has no effect (see comments in SetD2DInput below for more info).
+                    CanvasImageGetD2DImageFlags interopFlags = static_cast<CanvasImageGetD2DImageFlags>(flags & ~GetImageFlags::UnrealizeOnFailure);
+
+                    // If the input is not an ICanvasImageInternal, it must be an ICanvasImageInterop
+                    hr = As<ICanvasImageInterop>(source)->GetD2DImage(RealizationDevice(), deviceContext, interopFlags, targetDpi, &realizedDpi, &realizedSource);
+
+                    // If the call failed and UnrealizeOnFailure is not set, rethrow.
+                    if ((flags & GetImageFlags::UnrealizeOnFailure) == GetImageFlags::None)
+                        ThrowIfFailed(hr);
+                }
 
                 bool resourceChanged = sourceInfo.UpdateResource(realizedSource.Get());
 

--- a/winrt/lib/effects/CanvasEffect.cpp
+++ b/winrt/lib/effects/CanvasEffect.cpp
@@ -1102,16 +1102,11 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
             }
             else
             {
-                // The source is an external effect implementing ICanvasImageInterop, so we need to prepare the arguments to invoke it.
-                // They match the ones for ICanvasImageInternal::GetD2DImage, with the exception of the flags being slightly different.
-                // Specifically, the UnrealizeOnFailure flag is not present and should be removed, as this API is in a COM interface, so
-                // HRESULTs are used by default to propagate errors, and exceptions are never thrown. As such, that flag has no meaning.
+                // For more info on the following logic, see comments in ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource
                 CanvasImageGetD2DImageFlags interopFlags = static_cast<CanvasImageGetD2DImageFlags>(flags & ~GetImageFlags::UnrealizeOnFailure);
 
                 hr = interopSource->GetD2DImage(RealizationDevice(), deviceContext, interopFlags, targetDpi, &realizedDpi, &realizedSource);
 
-                // To match the behavior of ICanvasImageInternal::GetD2DImage in case of failure, check if the flags being used did have the
-                // GetImageFlags::UnrealizeOnFailure set. If not, and the call failed, then we explicitly throw from the returned HRESULT.
                 if ((flags & GetImageFlags::UnrealizeOnFailure) == GetImageFlags::None)
                     ThrowIfFailed(hr);
             }

--- a/winrt/lib/effects/CanvasEffect.h
+++ b/winrt/lib/effects/CanvasEffect.h
@@ -161,7 +161,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         // ICanvasImageInternal
         //
 
-        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* device, ID2D1DeviceContext* deviceContext, GetImageFlags flags, float targetDpi, float* realizedDpi = nullptr) override;
+        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* device, ID2D1DeviceContext* deviceContext, GetD2DImageFlags flags, float targetDpi, float* realizedDpi = nullptr) override;
 
         //
         // ICanvasResourceWrapperNative
@@ -276,15 +276,15 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
 
 
         // On-demand creation of the underlying D2D image effect.
-        virtual bool Realize(GetImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
+        virtual bool Realize(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
         virtual void Unrealize(unsigned int skipSourceIndex = UINT_MAX, bool skipAllSources = false);
 
     private:
         ComPtr<ID2D1Effect> CreateD2DEffect(ID2D1DeviceContext* deviceContext, IID const& effectId);
-        bool ApplyDpiCompensation(unsigned int index, ComPtr<ID2D1Image>& inputImage, float inputDpi, GetImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
-        void RefreshInputs(GetImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
+        bool ApplyDpiCompensation(unsigned int index, ComPtr<ID2D1Image>& inputImage, float inputDpi, GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
+        void RefreshInputs(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
         
-        bool SetD2DInput(ID2D1Effect* d2dEffect, unsigned int index, IGraphicsEffectSource* source, GetImageFlags flags, float targetDpi = 0, ID2D1DeviceContext* deviceContext = nullptr);
+        bool SetD2DInput(ID2D1Effect* d2dEffect, unsigned int index, IGraphicsEffectSource* source, GetD2DImageFlags flags, float targetDpi = 0, ID2D1DeviceContext* deviceContext = nullptr);
         ComPtr<IGraphicsEffectSource> GetD2DInput(ID2D1Effect* d2dEffect, unsigned int index);
 
         void SetProperty(unsigned int index, IPropertyValue* propertyValue);

--- a/winrt/lib/effects/CanvasEffect.h
+++ b/winrt/lib/effects/CanvasEffect.h
@@ -152,6 +152,12 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         IFACEMETHOD(GetBoundsWithTransform)(ICanvasResourceCreator* resourceCreator, Numerics::Matrix3x2 transform, Rect *bounds) override;
 
         //
+        // ICanvasImageInterop
+        //
+
+        IFACEMETHOD(GetDevice)(ICanvasDevice** device) override;
+
+        //
         // ICanvasImageInternal
         //
 

--- a/winrt/lib/effects/CanvasEffect.h
+++ b/winrt/lib/effects/CanvasEffect.h
@@ -37,7 +37,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
             IGraphicsEffectD2D1Interop,
             ICanvasEffect,
             ICanvasImage,
-            CloakedIid<ICanvasImageInternal>,
+            ChainInterfaces<CloakedIid<ICanvasImageInternal>, CloakedIid<ICanvasImageInterop>>,
             ChainInterfaces<
                 MixIn<CanvasEffect, ResourceWrapper<ID2D1Effect, CanvasEffect, IGraphicsEffect>>,
                 IClosable,

--- a/winrt/lib/effects/CanvasEffect.h
+++ b/winrt/lib/effects/CanvasEffect.h
@@ -161,7 +161,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
         // ICanvasImageInternal
         //
 
-        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* device, ID2D1DeviceContext* deviceContext, GetD2DImageFlags flags, float targetDpi, float* realizedDpi = nullptr) override;
+        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* device, ID2D1DeviceContext* deviceContext, WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, float* realizedDpi = nullptr) override;
 
         //
         // ICanvasResourceWrapperNative
@@ -276,15 +276,15 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
 
 
         // On-demand creation of the underlying D2D image effect.
-        virtual bool Realize(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
+        virtual bool Realize(WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, ID2D1DeviceContext* deviceContext);
         virtual void Unrealize(unsigned int skipSourceIndex = UINT_MAX, bool skipAllSources = false);
 
     private:
         ComPtr<ID2D1Effect> CreateD2DEffect(ID2D1DeviceContext* deviceContext, IID const& effectId);
-        bool ApplyDpiCompensation(unsigned int index, ComPtr<ID2D1Image>& inputImage, float inputDpi, GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
-        void RefreshInputs(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext);
+        bool ApplyDpiCompensation(unsigned int index, ComPtr<ID2D1Image>& inputImage, float inputDpi, WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, ID2D1DeviceContext* deviceContext);
+        void RefreshInputs(WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, ID2D1DeviceContext* deviceContext);
         
-        bool SetD2DInput(ID2D1Effect* d2dEffect, unsigned int index, IGraphicsEffectSource* source, GetD2DImageFlags flags, float targetDpi = 0, ID2D1DeviceContext* deviceContext = nullptr);
+        bool SetD2DInput(ID2D1Effect* d2dEffect, unsigned int index, IGraphicsEffectSource* source, WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi = 0, ID2D1DeviceContext* deviceContext = nullptr);
         ComPtr<IGraphicsEffectSource> GetD2DInput(ID2D1Effect* d2dEffect, unsigned int index);
 
         void SetProperty(unsigned int index, IPropertyValue* propertyValue);

--- a/winrt/lib/effects/shader/PixelShaderEffect.cpp
+++ b/winrt/lib/effects/shader/PixelShaderEffect.cpp
@@ -216,7 +216,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     }
 
 
-    bool PixelShaderEffect::Realize(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext)
+    bool PixelShaderEffect::Realize(WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, ID2D1DeviceContext* deviceContext)
     {
         // Validate that this device supports the D3D feature level of the pixel shader.
         if (!IsSupported(RealizationDevice()))

--- a/winrt/lib/effects/shader/PixelShaderEffect.cpp
+++ b/winrt/lib/effects/shader/PixelShaderEffect.cpp
@@ -216,7 +216,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     }
 
 
-    bool PixelShaderEffect::Realize(GetImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext)
+    bool PixelShaderEffect::Realize(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext)
     {
         // Validate that this device supports the D3D feature level of the pixel shader.
         if (!IsSupported(RealizationDevice()))

--- a/winrt/lib/effects/shader/PixelShaderEffect.h
+++ b/winrt/lib/effects/shader/PixelShaderEffect.h
@@ -88,7 +88,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     protected:
         bool IsSupported(ICanvasDevice* device);
 
-        virtual bool Realize(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext) override;
+        virtual bool Realize(WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, ID2D1DeviceContext* deviceContext) override;
         virtual void Unrealize(unsigned int skipSourceIndex, bool skipAllSources) override;
 
         IFACEMETHOD(GetSource)(unsigned int index, IGraphicsEffectSource** source) override;

--- a/winrt/lib/effects/shader/PixelShaderEffect.h
+++ b/winrt/lib/effects/shader/PixelShaderEffect.h
@@ -88,7 +88,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas { na
     protected:
         bool IsSupported(ICanvasDevice* device);
 
-        virtual bool Realize(GetImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext) override;
+        virtual bool Realize(GetD2DImageFlags flags, float targetDpi, ID2D1DeviceContext* deviceContext) override;
         virtual void Unrealize(unsigned int skipSourceIndex, bool skipAllSources) override;
 
         IFACEMETHOD(GetSource)(unsigned int index, IGraphicsEffectSource** source) override;

--- a/winrt/lib/images/CanvasBitmap.h
+++ b/winrt/lib/images/CanvasBitmap.h
@@ -491,6 +491,15 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 });
         }
 
+        //
+        // ICanvasImageInterop
+        //
+
+        IFACEMETHOD(GetDevice)(ICanvasDevice** device)
+        {
+            return get_Device(device);
+        }
+
         // ICanvasImageInternal
         virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice*, ID2D1DeviceContext*, GetImageFlags, float /*targetDpi*/, float* realizedDpi) override
         {

--- a/winrt/lib/images/CanvasBitmap.h
+++ b/winrt/lib/images/CanvasBitmap.h
@@ -501,7 +501,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         }
 
         // ICanvasImageInternal
-        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice*, ID2D1DeviceContext*, GetD2DImageFlags, float /*targetDpi*/, float* realizedDpi) override
+        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice*, ID2D1DeviceContext*, WIN2D_GET_D2D_IMAGE_FLAGS, float /*targetDpi*/, float* realizedDpi) override
         {
             if (realizedDpi)
                 *realizedDpi = m_dpi;

--- a/winrt/lib/images/CanvasBitmap.h
+++ b/winrt/lib/images/CanvasBitmap.h
@@ -501,7 +501,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         }
 
         // ICanvasImageInternal
-        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice*, ID2D1DeviceContext*, GetImageFlags, float /*targetDpi*/, float* realizedDpi) override
+        virtual ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice*, ID2D1DeviceContext*, GetD2DImageFlags, float /*targetDpi*/, float* realizedDpi) override
         {
             if (realizedDpi)
                 *realizedDpi = m_dpi;

--- a/winrt/lib/images/CanvasBitmap.h
+++ b/winrt/lib/images/CanvasBitmap.h
@@ -336,7 +336,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 RuntimeClassFlags<WinRtClassicComMix>,
                 ICanvasResourceCreator,
                 ICanvasResourceCreatorWithDpi,
-                CloakedIid<ICanvasImageInternal>,
+                ChainInterfaces<CloakedIid<ICanvasImageInternal>, CloakedIid<ICanvasImageInterop>>,
                 CloakedIid<ICanvasBitmapInternal>,
                 CloakedIid<IDirect3DDxgiInterfaceAccess>,
                 CloakedIid<ICanvasResourceWrapperWithDevice>>,

--- a/winrt/lib/images/CanvasCommandList.cpp
+++ b/winrt/lib/images/CanvasCommandList.cpp
@@ -147,7 +147,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     ComPtr<ID2D1Image> CanvasCommandList::GetD2DImage(
         ICanvasDevice* device,
         ID2D1DeviceContext* deviceContext,
-        GetD2DImageFlags,
+        WIN2D_GET_D2D_IMAGE_FLAGS,
         float /*targetDpi*/,
         float* realizedDpi)
     {

--- a/winrt/lib/images/CanvasCommandList.cpp
+++ b/winrt/lib/images/CanvasCommandList.cpp
@@ -147,7 +147,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     ComPtr<ID2D1Image> CanvasCommandList::GetD2DImage(
         ICanvasDevice* device,
         ID2D1DeviceContext* deviceContext,
-        GetImageFlags,
+        GetD2DImageFlags,
         float /*targetDpi*/,
         float* realizedDpi)
     {

--- a/winrt/lib/images/CanvasCommandList.h
+++ b/winrt/lib/images/CanvasCommandList.h
@@ -11,7 +11,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         CanvasCommandList,
         ICanvasCommandList,
         ICanvasImage,
-        CloakedIid<ICanvasImageInternal>,
+        ChainInterfaces<CloakedIid<ICanvasImageInternal>, CloakedIid<ICanvasImageInterop>>,
         CloakedIid<ICanvasResourceWrapperWithDevice>,
         Effects::IGraphicsEffectSource)
     {

--- a/winrt/lib/images/CanvasCommandList.h
+++ b/winrt/lib/images/CanvasCommandList.h
@@ -68,7 +68,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         virtual ComPtr<ID2D1Image> GetD2DImage(
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
-            GetImageFlags flags,
+            GetD2DImageFlags flags,
             float targetDpi,
             float* realizedDpi) override;
 

--- a/winrt/lib/images/CanvasCommandList.h
+++ b/winrt/lib/images/CanvasCommandList.h
@@ -68,7 +68,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         virtual ComPtr<ID2D1Image> GetD2DImage(
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
-            GetD2DImageFlags flags,
+            WIN2D_GET_D2D_IMAGE_FLAGS flags,
             float targetDpi,
             float* realizedDpi) override;
 

--- a/winrt/lib/images/CanvasCommandList.h
+++ b/winrt/lib/images/CanvasCommandList.h
@@ -54,6 +54,14 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             Numerics::Matrix3x2 transform,
             Rect* bounds) override;
 
+        //
+        // ICanvasImageInterop
+        //
+
+        IFACEMETHOD(GetDevice)(ICanvasDevice** device)
+        {
+            return get_Device(device);
+        }
 
         // ICanvasImageInternal
 

--- a/winrt/lib/images/CanvasImage.cpp
+++ b/winrt/lib/images/CanvasImage.cpp
@@ -86,7 +86,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     // Static helper for forwarding GetImageBoundsImpl support to ICanvasImageInterop consumers.
     // This is the implementation of the public GetBoundsForICanvasImageInterop exported function.
 
-    HRESULT GetBoundsForICanvasImageInterop(
+    extern "C" __declspec(nothrow, dllexport) HRESULT __stdcall GetBoundsForICanvasImageInterop(
         ICanvasResourceCreator* resourceCreator,
         ICanvasImageInterop* image,
         Numerics::Matrix3x2 const* transform,

--- a/winrt/lib/images/CanvasImage.cpp
+++ b/winrt/lib/images/CanvasImage.cpp
@@ -237,7 +237,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 auto canvasDevice = GetCanvasDevice(resourceCreator);
                 auto d2dDevice = GetWrappedResource<ID2D1Device>(canvasDevice);
 
-                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, canvasDevice.Get(), nullptr, GetImageFlags::None, dpi);
+                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, canvasDevice.Get(), nullptr, GetD2DImageFlags::None, dpi);
 
                 auto adapter = m_adapter;
                 auto istream = adapter->CreateStreamOverRandomAccessStream(stream);
@@ -299,7 +299,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 // Configure the atlas effect to select what region of the source image we want to feed into the histogram.
                 float realizedDpi;
 
-                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, device.Get(), deviceContext.Get(), GetImageFlags::None, DEFAULT_DPI, &realizedDpi);
+                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, device.Get(), deviceContext.Get(), GetD2DImageFlags::None, DEFAULT_DPI, &realizedDpi);
 
                 if (realizedDpi != 0 && realizedDpi != DEFAULT_DPI)
                 {

--- a/winrt/lib/images/CanvasImage.cpp
+++ b/winrt/lib/images/CanvasImage.cpp
@@ -237,7 +237,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 auto canvasDevice = GetCanvasDevice(resourceCreator);
                 auto d2dDevice = GetWrappedResource<ID2D1Device>(canvasDevice);
 
-                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, canvasDevice.Get(), nullptr, GetD2DImageFlags::None, dpi);
+                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, canvasDevice.Get(), nullptr, WIN2D_GET_D2D_IMAGE_FLAGS_NONE, dpi);
 
                 auto adapter = m_adapter;
                 auto istream = adapter->CreateStreamOverRandomAccessStream(stream);
@@ -299,7 +299,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 // Configure the atlas effect to select what region of the source image we want to feed into the histogram.
                 float realizedDpi;
 
-                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, device.Get(), deviceContext.Get(), GetD2DImageFlags::None, DEFAULT_DPI, &realizedDpi);
+                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, device.Get(), deviceContext.Get(), WIN2D_GET_D2D_IMAGE_FLAGS_NONE, DEFAULT_DPI, &realizedDpi);
 
                 if (realizedDpi != 0 && realizedDpi != DEFAULT_DPI)
                 {

--- a/winrt/lib/images/CanvasImage.cpp
+++ b/winrt/lib/images/CanvasImage.cpp
@@ -198,25 +198,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 auto canvasDevice = GetCanvasDevice(resourceCreator);
                 auto d2dDevice = GetWrappedResource<ID2D1Device>(canvasDevice);
 
-                ComPtr<ID2D1Image> d2dImage;
-                ComPtr<ICanvasImageInternal> internalSource;
-
-                HRESULT hr = image->QueryInterface(IID_PPV_ARGS(&internalSource));
-
-                // If QueryInterface failed in any way other than E_NOINTERFACE, we just rethrow (just like in CanvasEffect::SetD2DInput).
-                if (FAILED(hr) && hr != E_NOINTERFACE)
-                    ThrowHR(hr);
-
-                // If the input was indeed an ICanvasImageInternal, invoke its GetD2DImage method normally.
-                if (SUCCEEDED(hr))
-                {
-                    d2dImage = internalSource->GetD2DImage(canvasDevice.Get(), nullptr, GetImageFlags::None, dpi);
-                }
-                else
-                {
-                    // If the source is not an ICanvasImageInternal, it must be an ICanvasImageInterop object.
-                    ThrowIfFailed(As<ICanvasImageInterop>(image)->GetD2DImage(canvasDevice.Get(), nullptr, CanvasImageGetD2DImageFlags::None, dpi, nullptr, &d2dImage));
-                }
+                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, canvasDevice.Get(), nullptr, GetImageFlags::None, dpi);
 
                 auto adapter = m_adapter;
                 auto istream = adapter->CreateStreamOverRandomAccessStream(stream);
@@ -278,25 +260,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 // Configure the atlas effect to select what region of the source image we want to feed into the histogram.
                 float realizedDpi;
 
-                ComPtr<ID2D1Image> d2dImage;
-                ComPtr<ICanvasImageInternal> internalSource;
-
-                HRESULT hr = image->QueryInterface(IID_PPV_ARGS(&internalSource));
-
-                // If QueryInterface failed in any way other than E_NOINTERFACE, we just rethrow (just like in CanvasEffect::SetD2DInput).
-                if (FAILED(hr) && hr != E_NOINTERFACE)
-                    ThrowHR(hr);
-
-                // If the input was indeed an ICanvasImageInternal, invoke its GetD2DImage method normally.
-                if (SUCCEEDED(hr))
-                {
-                    d2dImage = internalSource->GetD2DImage(device.Get(), deviceContext.Get(), GetImageFlags::None, DEFAULT_DPI, &realizedDpi);
-                }
-                else
-                {
-                    // If the source is not an ICanvasImageInternal, it must be an ICanvasImageInterop object.
-                    ThrowIfFailed(As<ICanvasImageInterop>(image)->GetD2DImage(device.Get(), deviceContext.Get(), CanvasImageGetD2DImageFlags::None, DEFAULT_DPI, &realizedDpi, &d2dImage));
-                }
+                auto d2dImage = ICanvasImageInternal::GetD2DImageFromInternalOrInteropSource(image, device.Get(), deviceContext.Get(), GetImageFlags::None, DEFAULT_DPI, &realizedDpi);
 
                 if (realizedDpi != 0 && realizedDpi != DEFAULT_DPI)
                 {

--- a/winrt/lib/images/CanvasImage.h
+++ b/winrt/lib/images/CanvasImage.h
@@ -34,7 +34,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     ICanvasImageInternal : public ICanvasImageInterop
     {
     public:
-        IFACEMETHODIMP ICanvasImageInterop::GetOrCreateD2DImage(
+        IFACEMETHODIMP ICanvasImageInterop::GetD2DImage(
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
             CanvasImageGetD2DImageFlags flags,
@@ -42,11 +42,11 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             float* realizeDpi,
             ID2D1Image** ppImage)
         {
-            // GetOrCreateD2DImage is exposed as a COM interface to external users, so make sure exceptions never cross the ABI boundary.
+            // GetD2DImage is exposed as a COM interface to external users, so make sure exceptions never cross the ABI boundary.
             return ExceptionBoundary([&]
                 {
                     // CanvasImageGetD2DImageFlags matches GetImageFlags, except it doesn't have the UnrealizeOnFailure flag defined,
-                    // as that would have no meaning for GetOrCreateD2DImage (since not throwing is the only allowed behavior). As
+                    // as that would have no meaning for GetD2DImage (since not throwing is the only allowed behavior). As
                     // such, it is safe here to just statically cast the input CanvasImageGetD2DImageFlags value to GetImageFlags.
                     // All other arguments are just forwarded with no changes.
                     auto d2dImage = GetD2DImage(device, deviceContext, static_cast<GetImageFlags>(flags), targetDpi, realizeDpi);

--- a/winrt/lib/images/CanvasImage.h
+++ b/winrt/lib/images/CanvasImage.h
@@ -14,7 +14,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     using namespace ABI::Windows::Foundation;
     using namespace ABI::Windows::Storage::Streams;
 
-    DEFINE_ENUM_FLAG_OPERATORS(GetD2DImageFlags)
+    DEFINE_ENUM_FLAG_OPERATORS(WIN2D_GET_D2D_IMAGE_FLAGS)
 
 
     class __declspec(uuid("2F434224-053C-4978-87C4-CFAAFA2F4FAC"))
@@ -24,7 +24,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         IFACEMETHODIMP GetD2DImage(
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
-            GetD2DImageFlags flags,
+            WIN2D_GET_D2D_IMAGE_FLAGS flags,
             float targetDpi,
             float* realizeDpi,
             ID2D1Image** ppImage) override
@@ -42,16 +42,16 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         // For effects it triggers on-demand realization, which requires extra information.
         //
         // The device parameter is required, while deviceContext is optional (but recommended)
-        // except when the ReadDpiFromDeviceContext flag is specified. This is because not all
-        // callers of GetD2DImage have easy access to a context. It is always possible to get a
-        // resource creation context from the device, but the context is only actually necessary
-        // if a new effect realization needs to be created, so it is more efficient to have the
+        // except when the WIN2D_GET_D2D_IMAGE_FLAGS_READ_DPI_FROM_DEVICE_CONTEXT flag is specified.
+        // This is because not all callers of GetD2DImage have easy access to a context. It is always
+        // possible to get a resource creation context from the device, but the context is only actually
+        // necessary if a new effect realization needs to be created, so it is more efficient to have the
         // implementation do this lookup only if/when it turns out to be needed.
         //
         // targetDpi passes in the DPI of the target device context. This is used to
         // determine when a D2D1DpiCompensation effect needs to be inserted. Behavior of
-        // this parameter can be overridden by the flag values ReadDpiFromDeviceContext,
-        // AlwaysInsertDpiCompensation, or NeverInsertDpiCompensation.
+        // this parameter can be overridden by the flag values WIN2D_GET_D2D_IMAGE_FLAGS_READ_DPI_FROM_DEVICE_CONTEXT,
+        // WIN2D_GET_D2D_IMAGE_FLAGS_ALWAYS_INSERT_DPI_COMPENSATION, or WIN2D_GET_D2D_IMAGE_FLAGS_NEVER_INSERT_DPI_COMPENSATION.
         //
         // realizedDpi returns the DPI of a source bitmap, or zero if the image does not
         // have a fixed DPI. A D2D1DpiCompensation effect will be inserted if targetDpi
@@ -60,7 +60,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         virtual ComPtr<ID2D1Image> GetD2DImage(
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
-            GetD2DImageFlags flags = GetD2DImageFlags::ReadDpiFromDeviceContext,
+            WIN2D_GET_D2D_IMAGE_FLAGS flags = WIN2D_GET_D2D_IMAGE_FLAGS_READ_DPI_FROM_DEVICE_CONTEXT,
             float targetDpi = 0,
             float* realizedDpi = nullptr) = 0;
 
@@ -72,7 +72,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             IUnknown* canvasImage,
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
-            GetD2DImageFlags flags = GetD2DImageFlags::ReadDpiFromDeviceContext,
+            WIN2D_GET_D2D_IMAGE_FLAGS flags = WIN2D_GET_D2D_IMAGE_FLAGS_READ_DPI_FROM_DEVICE_CONTEXT,
             float targetDpi = 0,
             float* realizedDpi = nullptr)
         {
@@ -100,9 +100,9 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
                 // If the source is not an ICanvasImageInternal, it must be an ICanvasImageInterop object.
                 hr = As<ICanvasImageInterop>(canvasImage)->GetD2DImage(device, deviceContext, flags, targetDpi, realizedDpi, &d2dImage);
 
-                // To match the behavior of ICanvasImageInternal::GetD2DImage in case of failure, check if the flags being used did have the
-                // GetD2DImageFlags::UnrealizeOnFailure set. If not, and the call failed, then we explicitly throw from the returned HRESULT.
-                if ((flags & GetD2DImageFlags::UnrealizeOnFailure) == GetD2DImageFlags::None)
+                // To match the behavior of ICanvasImageInternal::GetD2DImage in case of failure, check if the flags being used did have the flag
+                // WIN2D_GET_D2D_IMAGE_FLAGS_UNREALIZE_ON_FAILURE set. If not, and the call failed, then we explicitly throw from the returned HRESULT.
+                if ((flags & WIN2D_GET_D2D_IMAGE_FLAGS_UNREALIZE_ON_FAILURE) == WIN2D_GET_D2D_IMAGE_FLAGS_NONE)
                     ThrowIfFailed(hr);
             }
 

--- a/winrt/lib/images/CanvasImage.h
+++ b/winrt/lib/images/CanvasImage.h
@@ -14,8 +14,6 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     using namespace ABI::Windows::Foundation;
     using namespace ABI::Windows::Storage::Streams;
 
-    DEFINE_ENUM_FLAG_OPERATORS(WIN2D_GET_D2D_IMAGE_FLAGS)
-
 
     class __declspec(uuid("2F434224-053C-4978-87C4-CFAAFA2F4FAC"))
     ICanvasImageInternal : public ICanvasImageInterop

--- a/winrt/lib/images/CanvasImage.h
+++ b/winrt/lib/images/CanvasImage.h
@@ -34,13 +34,13 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
     ICanvasImageInternal : public ICanvasImageInterop
     {
     public:
-        IFACEMETHODIMP ICanvasImageInterop::GetD2DImage(
+        IFACEMETHODIMP GetD2DImage(
             ICanvasDevice* device,
             ID2D1DeviceContext* deviceContext,
             CanvasImageGetD2DImageFlags flags,
             float targetDpi,
             float* realizeDpi,
-            ID2D1Image** ppImage)
+            ID2D1Image** ppImage) override
         {
             // GetD2DImage is exposed as a COM interface to external users, so make sure exceptions never cross the ABI boundary.
             return ExceptionBoundary([&]

--- a/winrt/lib/images/CanvasImage.h
+++ b/winrt/lib/images/CanvasImage.h
@@ -133,7 +133,6 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         }
     };
 
-
     HRESULT GetImageBoundsImpl(
         ICanvasImageInternal* imageInternal,
         ICanvasResourceCreator* resourceCreator,

--- a/winrt/lib/images/CanvasVirtualBitmap.cpp
+++ b/winrt/lib/images/CanvasVirtualBitmap.cpp
@@ -462,7 +462,7 @@ IFACEMETHODIMP CanvasVirtualBitmap::GetBoundsWithTransform(ICanvasResourceCreato
 }
 
 
-ComPtr<ID2D1Image> CanvasVirtualBitmap::GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetImageFlags, float, float* realizedDpi)
+ComPtr<ID2D1Image> CanvasVirtualBitmap::GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetD2DImageFlags, float, float* realizedDpi)
 {
     if (realizedDpi)
         *realizedDpi = 0;

--- a/winrt/lib/images/CanvasVirtualBitmap.cpp
+++ b/winrt/lib/images/CanvasVirtualBitmap.cpp
@@ -462,7 +462,7 @@ IFACEMETHODIMP CanvasVirtualBitmap::GetBoundsWithTransform(ICanvasResourceCreato
 }
 
 
-ComPtr<ID2D1Image> CanvasVirtualBitmap::GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetD2DImageFlags, float, float* realizedDpi)
+ComPtr<ID2D1Image> CanvasVirtualBitmap::GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, WIN2D_GET_D2D_IMAGE_FLAGS, float, float* realizedDpi)
 {
     if (realizedDpi)
         *realizedDpi = 0;

--- a/winrt/lib/images/CanvasVirtualBitmap.h
+++ b/winrt/lib/images/CanvasVirtualBitmap.h
@@ -85,7 +85,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         ICanvasVirtualBitmap,
         ICanvasImage,
         IGraphicsEffectSource,
-        CloakedIid<ICanvasImageInternal>,
+        ChainInterfaces<CloakedIid<ICanvasImageInternal>, CloakedIid<ICanvasImageInterop>>,
         CloakedIid<ICanvasResourceWrapperWithDevice>)        
     {
         InspectableClass(RuntimeClass_Microsoft_Graphics_Canvas_CanvasVirtualBitmap, BaseTrust);

--- a/winrt/lib/images/CanvasVirtualBitmap.h
+++ b/winrt/lib/images/CanvasVirtualBitmap.h
@@ -137,7 +137,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         }
 
         // ICanvasImageInternal
-        ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetImageFlags, float, float*) override;
+        ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetD2DImageFlags, float, float*) override;
     };
 
 }}}}

--- a/winrt/lib/images/CanvasVirtualBitmap.h
+++ b/winrt/lib/images/CanvasVirtualBitmap.h
@@ -137,7 +137,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         }
 
         // ICanvasImageInternal
-        ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetD2DImageFlags, float, float*) override;
+        ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, WIN2D_GET_D2D_IMAGE_FLAGS, float, float*) override;
     };
 
 }}}}

--- a/winrt/lib/images/CanvasVirtualBitmap.h
+++ b/winrt/lib/images/CanvasVirtualBitmap.h
@@ -127,6 +127,15 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
         IFACEMETHODIMP GetBounds(ICanvasResourceCreator*, Rect*) override;
         IFACEMETHODIMP GetBoundsWithTransform(ICanvasResourceCreator*, Matrix3x2, Rect*) override;
 
+        //
+        // ICanvasImageInterop
+        //
+
+        IFACEMETHOD(GetDevice)(ICanvasDevice** device)
+        {
+            return get_Device(device);
+        }
+
         // ICanvasImageInternal
         ComPtr<ID2D1Image> GetD2DImage(ICanvasDevice* , ID2D1DeviceContext*, GetImageFlags, float, float*) override;
     };

--- a/winrt/lib/winrt.lib.uap.vcxproj
+++ b/winrt/lib/winrt.lib.uap.vcxproj
@@ -34,6 +34,7 @@
       <PreprocessorDefinitions>WRT_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/winrt/lib/winrt.lib.uap.vcxproj
+++ b/winrt/lib/winrt.lib.uap.vcxproj
@@ -21,6 +21,9 @@
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDir)..\..\build\midlrt.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Target Name="CleanIntermediateFiles" AfterTargets="Build" Condition="'$(AzurePipeline)'!=''">
+    <RemoveDir Directories="" />
+  </Target>
   <ItemDefinitionGroup>
     <Midl>
       <AdditionalIncludeDirectories>..\..\Numerics\WinRT;directx</AdditionalIncludeDirectories>
@@ -30,6 +33,7 @@
       <AdditionalIncludeDirectories>..\Inc;$(EtwDirectory);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WRT_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -40,6 +40,32 @@ namespace ABI
                 public:
                     IFACEMETHOD(GetNativeResource)(ICanvasDevice* device, float dpi, REFIID iid, void** resource) = 0;
                 };
+
+                typedef enum CanvasImageGetD2DImageFlags
+                {
+                    None = 0,
+                    ReadDpiFromDeviceContext = 1,    // Ignore the targetDpi parameter - read DPI from deviceContext instead
+                    AlwaysInsertDpiCompensation = 2, // Ignore the targetDpi parameter - always insert DPI compensation
+                    NeverInsertDpiCompensation = 4,  // Ignore the targetDpi parameter - never insert DPI compensation
+                    MinimalRealization = 8,          // Do the bare minimum to get back an ID2D1Image - no validation or recursive realization
+                    AllowNullEffectInputs = 16,      // Allow partially configured effect graphs where some inputs are null
+                } CanvasImageGetD2DImageFlags;
+
+                //
+                // Interface implemented by all effects and also exposed to allow external users to implement custom effects.
+                //
+                class __declspec(uuid("E042D1F7-F9AD-4479-A713-67627EA31863"))
+                ICanvasImageInterop : public IUnknown
+                {
+                public:
+                    IFACEMETHOD(GetOrCreateD2DImage)(
+                        ICanvasDevice* device,
+                        ID2D1DeviceContext* deviceContext,
+                        CanvasImageGetD2DImageFlags flags,
+                        float targetDpi,
+                        float* realizeDpi,
+                        ID2D1Image** ppImage) = 0;
+                };
             }
         }
     }

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -46,16 +46,16 @@ namespace ABI
                 };
 
                 // Options for fine-tuning the behavior of ICanvasImageInterop::GetD2DImage.
-                typedef enum GetD2DImageFlags
+                typedef enum WIN2D_GET_D2D_IMAGE_FLAGS
                 {
-                    None = 0,
-                    ReadDpiFromDeviceContext = 1,    // Ignore the targetDpi parameter - read DPI from deviceContext instead
-                    AlwaysInsertDpiCompensation = 2, // Ignore the targetDpi parameter - always insert DPI compensation
-                    NeverInsertDpiCompensation = 4,  // Ignore the targetDpi parameter - never insert DPI compensation
-                    MinimalRealization = 8,          // Do the bare minimum to get back an ID2D1Image - no validation or recursive realization
-                    AllowNullEffectInputs = 16,      // Allow partially configured effect graphs where some inputs are null
-                    UnrealizeOnFailure = 32,         // If an input is invalid, unrealize the effect and set the output image to null
-                } GetD2DImageFlags;
+                    WIN2D_GET_D2D_IMAGE_FLAGS_NONE = 0,
+                    WIN2D_GET_D2D_IMAGE_FLAGS_READ_DPI_FROM_DEVICE_CONTEXT = 1,    // Ignore the targetDpi parameter - read DPI from deviceContext instead
+                    WIN2D_GET_D2D_IMAGE_FLAGS_ALWAYS_INSERT_DPI_COMPENSATION = 2,  // Ignore the targetDpi parameter - always insert DPI compensation
+                    WIN2D_GET_D2D_IMAGE_FLAGS_NEVER_INSERT_DPI_COMPENSATION = 4,   // Ignore the targetDpi parameter - never insert DPI compensation
+                    WIN2D_GET_D2D_IMAGE_FLAGS_MINIMAL_REALIZATION = 8,             // Do the bare minimum to get back an ID2D1Image - no validation or recursive realization
+                    WIN2D_GET_D2D_IMAGE_FLAGS_ALLOW_NULL_EFFECT_INPUTS = 16,       // Allow partially configured effect graphs where some inputs are null
+                    WIN2D_GET_D2D_IMAGE_FLAGS_UNREALIZE_ON_FAILURE = 32,           // If an input is invalid, unrealize the effect and set the output image to null
+                } WIN2D_GET_D2D_IMAGE_FLAGS;
 
                 //
                 // Interface implemented by all effects and also exposed to allow external users to implement custom effects.
@@ -69,7 +69,7 @@ namespace ABI
                     IFACEMETHOD(GetD2DImage)(
                         ICanvasDevice* device,
                         ID2D1DeviceContext* deviceContext,
-                        GetD2DImageFlags flags,
+                        WIN2D_GET_D2D_IMAGE_FLAGS flags,
                         float targetDpi,
                         float* realizeDpi,
                         ID2D1Image** ppImage) = 0;

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -55,6 +55,7 @@ namespace ABI
                     WIN2D_GET_D2D_IMAGE_FLAGS_MINIMAL_REALIZATION = 8,             // Do the bare minimum to get back an ID2D1Image - no validation or recursive realization
                     WIN2D_GET_D2D_IMAGE_FLAGS_ALLOW_NULL_EFFECT_INPUTS = 16,       // Allow partially configured effect graphs where some inputs are null
                     WIN2D_GET_D2D_IMAGE_FLAGS_UNREALIZE_ON_FAILURE = 32,           // If an input is invalid, unrealize the effect and set the output image to null
+                    WIN2D_GET_D2D_IMAGE_FLAGS_FORCE_DWORD = 0xffffffff
                 } WIN2D_GET_D2D_IMAGE_FLAGS;
 
                 DEFINE_ENUM_FLAG_OPERATORS(WIN2D_GET_D2D_IMAGE_FLAGS)

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -57,6 +57,8 @@ namespace ABI
                     WIN2D_GET_D2D_IMAGE_FLAGS_UNREALIZE_ON_FAILURE = 32,           // If an input is invalid, unrealize the effect and set the output image to null
                 } WIN2D_GET_D2D_IMAGE_FLAGS;
 
+                DEFINE_ENUM_FLAG_OPERATORS(WIN2D_GET_D2D_IMAGE_FLAGS)
+
                 //
                 // Interface implemented by all effects and also exposed to allow external users to implement custom effects.
                 //

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -58,6 +58,8 @@ namespace ABI
                 ICanvasImageInterop : public IUnknown
                 {
                 public:
+                    IFACEMETHOD(GetDevice)(ICanvasDevice** device) = 0;
+
                     IFACEMETHOD(GetOrCreateD2DImage)(
                         ICanvasDevice* device,
                         ID2D1DeviceContext* deviceContext,

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <inspectable.h>
+#include <windows.foundation.numerics.h>
 #include <wrl.h>
 
 interface ID2D1Device1;

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -17,7 +17,10 @@ namespace ABI
         {
             namespace Canvas
             {
+                using namespace ABI::Windows::Foundation;
+
                 interface ICanvasDevice;
+                interface ICanvasResourceCreator;
 
                 //
                 // Interface provided by the CanvasDevice factory that is
@@ -68,6 +71,15 @@ namespace ABI
                         float* realizeDpi,
                         ID2D1Image** ppImage) = 0;
                 };
+
+                //
+                // Exported method to allow ICanvasImageInterop implementors to implement ICanvasImage properly.
+                //
+                extern "C" __declspec(nothrow, dllexport) HRESULT __stdcall GetBoundsForICanvasImageInterop(
+                    ICanvasResourceCreator* resourceCreator,
+                    ICanvasImageInterop* image,
+                    Numerics::Matrix3x2 const* transform,
+                    Rect* rect);
             }
         }
     }

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -60,7 +60,7 @@ namespace ABI
                 public:
                     IFACEMETHOD(GetDevice)(ICanvasDevice** device) = 0;
 
-                    IFACEMETHOD(GetOrCreateD2DImage)(
+                    IFACEMETHOD(GetD2DImage)(
                         ICanvasDevice* device,
                         ID2D1DeviceContext* deviceContext,
                         CanvasImageGetD2DImageFlags flags,

--- a/winrt/published/Microsoft.Graphics.Canvas.native.h
+++ b/winrt/published/Microsoft.Graphics.Canvas.native.h
@@ -44,7 +44,8 @@ namespace ABI
                     IFACEMETHOD(GetNativeResource)(ICanvasDevice* device, float dpi, REFIID iid, void** resource) = 0;
                 };
 
-                typedef enum CanvasImageGetD2DImageFlags
+                // Options for fine-tuning the behavior of ICanvasImageInterop::GetD2DImage.
+                typedef enum GetD2DImageFlags
                 {
                     None = 0,
                     ReadDpiFromDeviceContext = 1,    // Ignore the targetDpi parameter - read DPI from deviceContext instead
@@ -52,7 +53,8 @@ namespace ABI
                     NeverInsertDpiCompensation = 4,  // Ignore the targetDpi parameter - never insert DPI compensation
                     MinimalRealization = 8,          // Do the bare minimum to get back an ID2D1Image - no validation or recursive realization
                     AllowNullEffectInputs = 16,      // Allow partially configured effect graphs where some inputs are null
-                } CanvasImageGetD2DImageFlags;
+                    UnrealizeOnFailure = 32,         // If an input is invalid, unrealize the effect and set the output image to null
+                } GetD2DImageFlags;
 
                 //
                 // Interface implemented by all effects and also exposed to allow external users to implement custom effects.
@@ -66,7 +68,7 @@ namespace ABI
                     IFACEMETHOD(GetD2DImage)(
                         ICanvasDevice* device,
                         ID2D1DeviceContext* deviceContext,
-                        CanvasImageGetD2DImageFlags flags,
+                        GetD2DImageFlags flags,
                         float targetDpi,
                         float* realizeDpi,
                         ID2D1Image** ppImage) = 0;

--- a/winrt/test.external/CanvasImageInteropTests.cpp
+++ b/winrt/test.external/CanvasImageInteropTests.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+#include "pch.h"
+
+using ABI::Microsoft::Graphics::Canvas::ICanvasImageInterop;
+using ABI::Microsoft::Graphics::Canvas::WIN2D_GET_D2D_IMAGE_FLAGS;
+using namespace Microsoft::Graphics::Canvas;
+using namespace Microsoft::Graphics::Canvas::Effects;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI;
+using namespace Windows::Devices::Enumeration;
+using namespace Platform;
+
+TEST_CLASS(CanvasImageInteropTests)
+{
+    // This class is a thin wrapper around an input effect, which forwards all API calls directly to it.
+    // It's used to validate that other Win2D APIs can accept an input that is only an ICanvasImageInterop.
+    class WrappedEffect : public RuntimeClass<
+        RuntimeClassFlags<WinRtClassicComMix>,
+        ABI::Microsoft::Graphics::Canvas::ICanvasImage,
+        ABI::Windows::Graphics::Effects::IGraphicsEffectSource,
+        ABI::Windows::Foundation::IClosable,
+        ICanvasImageInterop>
+    {
+        InspectableClass(L"EffectsAbi::IGraphicsEffectD2D1Interop::WrappedEffect", TrustLevel::BaseTrust);
+
+        ComPtr<ABI::Microsoft::Graphics::Canvas::ICanvasImage> m_canvasImage;
+
+    public:
+        WrappedEffect(Microsoft::Graphics::Canvas::ICanvasImage^ canvasImage)
+        {
+            As<IUnknown>(canvasImage).CopyTo(&m_canvasImage);
+        }
+
+        // ICanvasImage
+
+        IFACEMETHODIMP GetBounds(
+            ABI::Microsoft::Graphics::Canvas::ICanvasResourceCreator* resourceCreator,
+            ABI::Windows::Foundation::Rect* bounds
+        ) override
+        {
+            return m_canvasImage->GetBounds(resourceCreator, bounds);
+        }
+
+        IFACEMETHODIMP GetBoundsWithTransform(
+            ABI::Microsoft::Graphics::Canvas::ICanvasResourceCreator* resourceCreator,
+            ABI::Windows::Foundation::Numerics::Matrix3x2 transform,
+            ABI::Windows::Foundation::Rect* bounds
+        ) override
+        {
+            return m_canvasImage->GetBoundsWithTransform(resourceCreator, transform, bounds);
+        }
+
+        // IClosable
+
+        IFACEMETHODIMP Close() override
+        {
+            return As<ABI::Windows::Foundation::IClosable>(m_canvasImage.Get())->Close();
+        }
+
+        // ICanvasImageInterop
+
+        IFACEMETHODIMP GetDevice(ABI::Microsoft::Graphics::Canvas::ICanvasDevice** device) override
+        {
+            return As<ICanvasImageInterop>(m_canvasImage.Get())->GetDevice(device);
+        }
+
+        IFACEMETHODIMP GetD2DImage(
+            ABI::Microsoft::Graphics::Canvas::ICanvasDevice* device,
+            ID2D1DeviceContext* deviceContext,
+            WIN2D_GET_D2D_IMAGE_FLAGS flags,
+            float targetDpi,
+            float* realizeDpi,
+            ID2D1Image** ppImage) override
+        {
+            return As<ICanvasImageInterop>(m_canvasImage.Get())->GetD2DImage(
+                device,
+                deviceContext,
+                flags,
+                targetDpi,
+                realizeDpi,
+                ppImage);
+        }
+    };
+
+    TEST_METHOD(WrappedEffect_FromCanvasBitmap_CanvasDrawingSessionDrawImage)
+    {
+        auto deviceContext = CreateTestD2DDeviceContext();
+        auto drawingSession = GetOrCreate<CanvasDrawingSession>(deviceContext.Get());
+
+        auto canvasBitmap = CanvasBitmap::CreateFromColors(
+            drawingSession->Device,
+            ref new Platform::Array<Color>(1),
+            256,
+            256,
+            96.0f,
+            CanvasAlphaMode::Ignore);
+
+        auto wrappedEffect = Make<WrappedEffect>(canvasBitmap);
+
+        ICanvasImage^ canvasImage = reinterpret_cast<ICanvasImage^>(As<ABI::Microsoft::Graphics::Canvas::ICanvasImage>(wrappedEffect.Get()).Get());
+
+        // Draw an image passing the wrapping effect implementing ICanvasImage externally
+        drawingSession->DrawImage(canvasImage);
+    }
+
+    TEST_METHOD(WrappedEffect_FromCanvasBitmap_AsOtherEffectSource_CanvasDrawingSessionDrawImage)
+    {
+        auto deviceContext = CreateTestD2DDeviceContext();
+        auto drawingSession = GetOrCreate<CanvasDrawingSession>(deviceContext.Get());
+
+        auto canvasBitmap = CanvasBitmap::CreateFromColors(
+            drawingSession->Device,
+            ref new Platform::Array<Color>(1),
+            256,
+            256,
+            96.0f,
+            CanvasAlphaMode::Ignore);
+
+        auto wrappedEffect = Make<WrappedEffect>(canvasBitmap);
+
+        auto blurEffect = ref new GaussianBlurEffect();
+
+        IGraphicsEffectSource^ effectSource = reinterpret_cast<ICanvasImage^>(As<ABI::Windows::Graphics::Effects::IGraphicsEffectSource>(wrappedEffect.Get()).Get());
+
+        // Assign the wrapper as source for an effect to validate that built-in effects can also accept external ICanvasImage objects
+        blurEffect->Source = effectSource;
+
+        drawingSession->DrawImage(blurEffect);
+    }
+};

--- a/winrt/test.external/CanvasImageInteropTests.cpp
+++ b/winrt/test.external/CanvasImageInteropTests.cpp
@@ -103,7 +103,12 @@ TEST_CLASS(CanvasImageInteropTests)
         ICanvasImage^ canvasImage = reinterpret_cast<ICanvasImage^>(As<ABI::Microsoft::Graphics::Canvas::ICanvasImage>(wrappedEffect.Get()).Get());
 
         // Draw an image passing the wrapping effect implementing ICanvasImage externally
+        ComPtr<ID2D1CommandList> d2dCommandList;
+        ThrowIfFailed(deviceContext->CreateCommandList(&d2dCommandList));
+        deviceContext->SetTarget(d2dCommandList.Get());
+        deviceContext->BeginDraw();
         drawingSession->DrawImage(canvasImage);
+        ThrowIfFailed(deviceContext->EndDraw());
     }
 
     TEST_METHOD(WrappedEffect_FromCanvasEffect_CanvasDrawingSessionDrawImage)
@@ -128,7 +133,12 @@ TEST_CLASS(CanvasImageInteropTests)
 
         ICanvasImage^ canvasImage = reinterpret_cast<ICanvasImage^>(As<ABI::Microsoft::Graphics::Canvas::ICanvasImage>(wrappedEffect.Get()).Get());
 
+        ComPtr<ID2D1CommandList> d2dCommandList;
+        ThrowIfFailed(deviceContext->CreateCommandList(&d2dCommandList));
+        deviceContext->SetTarget(d2dCommandList.Get());
+        deviceContext->BeginDraw();
         drawingSession->DrawImage(canvasImage);
+        ThrowIfFailed(deviceContext->EndDraw());
     }
 
     TEST_METHOD(WrappedEffect_FromCanvasBitmap_AsOtherEffectSource_CanvasDrawingSessionDrawImage)
@@ -153,7 +163,12 @@ TEST_CLASS(CanvasImageInteropTests)
         // Assign the wrapper as source for an effect to validate that built-in effects can also accept external ICanvasImage objects
         blurEffect->Source = effectSource;
 
+        ComPtr<ID2D1CommandList> d2dCommandList;
+        ThrowIfFailed(deviceContext->CreateCommandList(&d2dCommandList));
+        deviceContext->SetTarget(d2dCommandList.Get());
+        deviceContext->BeginDraw();
         drawingSession->DrawImage(blurEffect);
+        ThrowIfFailed(deviceContext->EndDraw());
     }
 
     TEST_METHOD(WrappedEffect_FromCanvasBitmap_GetBoundsForICanvasImageInterop)

--- a/winrt/test.external/CanvasImageInteropTests.cpp
+++ b/winrt/test.external/CanvasImageInteropTests.cpp
@@ -176,6 +176,7 @@ TEST_CLASS(CanvasImageInteropTests)
         ThrowIfFailed(wrappedEffect->GetDevice(&canvasDevice));
         ThrowIfFailed(canvasDevice.CopyTo(IID_PPV_ARGS(&canvasResourceCreator)));
 
+        // A canvas bitmap has an associated device from creation
         Assert::IsNotNull(canvasDevice.Get());
         Assert::IsNotNull(canvasResourceCreator.Get());
 
@@ -220,12 +221,10 @@ TEST_CLASS(CanvasImageInteropTests)
         auto wrappedEffect = Make<WrappedEffect>(blurEffect);
 
         ComPtr<ABI::Microsoft::Graphics::Canvas::ICanvasDevice> canvasDevice;
-        ComPtr<ABI::Microsoft::Graphics::Canvas::ICanvasResourceCreator> canvasResourceCreator;
         ThrowIfFailed(wrappedEffect->GetDevice(&canvasDevice));
-        ThrowIfFailed(canvasDevice.CopyTo(IID_PPV_ARGS(&canvasResourceCreator)));
 
-        Assert::IsNotNull(canvasDevice.Get());
-        Assert::IsNotNull(canvasResourceCreator.Get());
+        // An effect has no associated device until it's realized (and it isn't at this point yet)
+        Assert::IsNull(canvasDevice.Get());
 
         auto canvasImageInterop = As<ABI::Microsoft::Graphics::Canvas::ICanvasImageInterop>(canvasBitmap);
 
@@ -233,7 +232,7 @@ TEST_CLASS(CanvasImageInteropTests)
 
         // Test GetBoundsForICanvasImageInterop with an effect going through a second Win2D effect first
         ThrowIfFailed(ABI::Microsoft::Graphics::Canvas::GetBoundsForICanvasImageInterop(
-            canvasResourceCreator.Get(),
+            As<ABI::Microsoft::Graphics::Canvas::ICanvasResourceCreator>(drawingSession).Get(),
             canvasImageInterop.Get(),
             nullptr,
             &rect));

--- a/winrt/test.external/pch.h
+++ b/winrt/test.external/pch.h
@@ -37,6 +37,8 @@
 #include <ComArray.h>
 #include <collection.h>
 
+#include <windows.foundation.h>
+
 #include <windowsnumerics.h>
 
 #include <Microsoft.Graphics.Canvas.native.h>

--- a/winrt/test.external/winrt.test.external.uap.vcxproj
+++ b/winrt/test.external/winrt.test.external.uap.vcxproj
@@ -7,11 +7,10 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
-    <UnitTestPlatformVersion  Condition="'$(UnitTestPlatformVersion)' == ''">16.0</UnitTestPlatformVersion>
+    <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">16.0</UnitTestPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-
   </PropertyGroup>
   <Import Project="..\..\build\Win2D.cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -39,6 +38,7 @@
     <ClCompile Include="CanvasCreateResourcesEventArgsTests.cpp" />
     <ClCompile Include="CanvasDeviceTests.cpp" />
     <ClCompile Include="CanvasBitmapTests.cpp" />
+    <ClCompile Include="CanvasImageInteropTests.cpp" />
     <ClCompile Include="CanvasSvgAttributeTests.cpp" />
     <ClCompile Include="CanvasVirtualBitmapTests.cpp" />
     <ClCompile Include="CanvasEffectsTests.cpp" />

--- a/winrt/test.external/winrt.test.external.uap.vcxproj.filters
+++ b/winrt/test.external/winrt.test.external.uap.vcxproj.filters
@@ -41,6 +41,7 @@
     <ClCompile Include="ColorManagementProfileTests.cpp" />
     <ClCompile Include="CanvasSvgDocumentTests.cpp" />
     <ClCompile Include="CanvasSvgAttributeTests.cpp" />
+    <ClCompile Include="CanvasImageInteropTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/winrt/test.internal/graphics/CanvasBitmapUnitTest.cpp
+++ b/winrt/test.internal/graphics/CanvasBitmapUnitTest.cpp
@@ -64,6 +64,7 @@ TEST_CLASS(CanvasBitmapUnitTest)
         ASSERT_IMPLEMENTS_INTERFACE(canvasBitmap, IDirect3DSurface);
         ASSERT_IMPLEMENTS_INTERFACE(canvasBitmap, ABI::Windows::Foundation::IClosable);
         ASSERT_IMPLEMENTS_INTERFACE(canvasBitmap, IDirect3DDxgiInterfaceAccess);
+        ASSERT_IMPLEMENTS_INTERFACE(canvasBitmap, ICanvasImageInterop);
         ASSERT_IMPLEMENTS_INTERFACE(canvasBitmap, ICanvasImageInternal);
         ASSERT_IMPLEMENTS_INTERFACE(canvasBitmap, ICanvasBitmapInternal);
     }

--- a/winrt/test.internal/graphics/CanvasBitmapUnitTest.cpp
+++ b/winrt/test.internal/graphics/CanvasBitmapUnitTest.cpp
@@ -111,6 +111,16 @@ TEST_CLASS(CanvasBitmapUnitTest)
         Assert::AreEqual<ICanvasDevice*>(f.m_canvasDevice.Get(), actualDevice.Get());
     }
 
+    TEST_METHOD_EX(CanvasBitmap_GetDevice_FromICanvasImageInterop)
+    {
+        Fixture f;
+        auto bitmap = CanvasBitmap::CreateNew(f.m_canvasDevice.Get(), f.m_testFileName, DEFAULT_DPI, CanvasAlphaMode::Premultiplied);
+
+        ComPtr<ICanvasDevice> actualDevice;
+        As<ICanvasImageInterop>(bitmap)->GetDevice(&actualDevice);
+        Assert::AreEqual<ICanvasDevice*>(f.m_canvasDevice.Get(), actualDevice.Get());
+    }
+
     TEST_METHOD_EX(CanvasBitmap_GetAlphaMode)
     {
         Fixture f;

--- a/winrt/test.internal/graphics/CanvasEffectUnitTest.cpp
+++ b/winrt/test.internal/graphics/CanvasEffectUnitTest.cpp
@@ -226,7 +226,7 @@ public:
                     mockEffect->MockGetInput =
                         [&](UINT32, ID2D1Image** input)
                         {
-                            ThrowIfFailed(stubBitmap->GetD2DImage(nullptr, nullptr, (GetImageFlags)0, 0, nullptr).CopyTo(input));
+                            ThrowIfFailed(stubBitmap->GetD2DImage(nullptr, nullptr, (GetD2DImageFlags)0, 0, nullptr).CopyTo(input));
                         };
 
                     mockEffect->MockGetInputCount =

--- a/winrt/test.internal/graphics/CanvasEffectUnitTest.cpp
+++ b/winrt/test.internal/graphics/CanvasEffectUnitTest.cpp
@@ -38,6 +38,7 @@ public:
         ASSERT_IMPLEMENTS_INTERFACE(m_testEffect, IGraphicsEffectSource);
         ASSERT_IMPLEMENTS_INTERFACE(m_testEffect, ABI::Windows::Foundation::IClosable);
         ASSERT_IMPLEMENTS_INTERFACE(m_testEffect, ICanvasImage);
+        ASSERT_IMPLEMENTS_INTERFACE(m_testEffect, ICanvasImageInterop);
         ASSERT_IMPLEMENTS_INTERFACE(m_testEffect, ICanvasImageInternal);
         ASSERT_IMPLEMENTS_INTERFACE(m_testEffect, IGaussianBlurEffect);
     }

--- a/winrt/test.internal/graphics/CanvasEffectUnitTest.cpp
+++ b/winrt/test.internal/graphics/CanvasEffectUnitTest.cpp
@@ -227,7 +227,7 @@ public:
                     mockEffect->MockGetInput =
                         [&](UINT32, ID2D1Image** input)
                         {
-                            ThrowIfFailed(stubBitmap->GetD2DImage(nullptr, nullptr, (GetD2DImageFlags)0, 0, nullptr).CopyTo(input));
+                            ThrowIfFailed(stubBitmap->GetD2DImage(nullptr, nullptr, WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0, nullptr).CopyTo(input));
                         };
 
                     mockEffect->MockGetInputCount =

--- a/winrt/test.internal/graphics/CanvasRenderTargetUnitTests.cpp
+++ b/winrt/test.internal/graphics/CanvasRenderTargetUnitTests.cpp
@@ -75,6 +75,7 @@ TEST_CLASS(CanvasRenderTargetTests)
         ASSERT_IMPLEMENTS_INTERFACE(renderTarget, ICanvasBitmap);
         ASSERT_IMPLEMENTS_INTERFACE(renderTarget, ICanvasImage);
         ASSERT_IMPLEMENTS_INTERFACE(renderTarget, ABI::Windows::Foundation::IClosable);
+        ASSERT_IMPLEMENTS_INTERFACE(renderTarget, ICanvasImageInterop);
         ASSERT_IMPLEMENTS_INTERFACE(renderTarget, ICanvasImageInternal);
     }
 

--- a/winrt/test.internal/graphics/CanvasVirtualBitmapUnitTests.cpp
+++ b/winrt/test.internal/graphics/CanvasVirtualBitmapUnitTests.cpp
@@ -230,7 +230,7 @@ TEST_CLASS(CanvasVirtualBitmapUnitTest)
         CreatedFixture f;
 
         float realizedDpi = 0;
-        auto d2dImage = f.VirtualBitmap->GetD2DImage(nullptr, nullptr, GetImageFlags::None, 0.0f, &realizedDpi);
+        auto d2dImage = f.VirtualBitmap->GetD2DImage(nullptr, nullptr, GetD2DImageFlags::None, 0.0f, &realizedDpi);
 
         Assert::IsTrue(IsSameInstance(f.ImageSource.Get(), d2dImage.Get()));
         Assert::AreEqual(0.0f, realizedDpi);

--- a/winrt/test.internal/graphics/CanvasVirtualBitmapUnitTests.cpp
+++ b/winrt/test.internal/graphics/CanvasVirtualBitmapUnitTests.cpp
@@ -243,7 +243,7 @@ TEST_CLASS(CanvasVirtualBitmapUnitTest)
         CreatedFixture f;
 
         float realizedDpi = 0;
-        auto d2dImage = f.VirtualBitmap->GetD2DImage(nullptr, nullptr, GetD2DImageFlags::None, 0.0f, &realizedDpi);
+        auto d2dImage = f.VirtualBitmap->GetD2DImage(nullptr, nullptr, WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0.0f, &realizedDpi);
 
         Assert::IsTrue(IsSameInstance(f.ImageSource.Get(), d2dImage.Get()));
         Assert::AreEqual(0.0f, realizedDpi);

--- a/winrt/test.internal/graphics/CanvasVirtualBitmapUnitTests.cpp
+++ b/winrt/test.internal/graphics/CanvasVirtualBitmapUnitTests.cpp
@@ -112,6 +112,19 @@ TEST_CLASS(CanvasVirtualBitmapUnitTest)
         Assert::IsTrue(IsSameInstance(f.Device.Get(), actualDevice.Get()));
     }
 
+    TEST_METHOD_EX(CanvasVirtualBitmap_CreateNew_Untransformed_CallsThrough_FromICanvasImageInterop)
+    {
+        Fixture f;
+
+        auto imageSource = f.ExpectCreateImageSourceFromWic(D2D1_IMAGE_SOURCE_LOADING_OPTIONS_NONE, D2D1_ALPHA_MODE_PREMULTIPLIED);
+
+        auto virtualBitmap = f.CreateVirtualBitmap(CanvasVirtualBitmapOptions::None, CanvasAlphaMode::Premultiplied);
+
+        ComPtr<ICanvasDevice> actualDevice;
+        ThrowIfFailed(As<ICanvasImageInterop>(virtualBitmap)->GetDevice(&actualDevice));
+        Assert::IsTrue(IsSameInstance(f.Device.Get(), actualDevice.Get()));
+    }
+
     TEST_METHOD_EX(CanvasVirtualBitmap_CreateNew_PassesCorrectAlphaModeThrough)
     {
         for (auto alphaMode : { CanvasAlphaMode::Premultiplied, CanvasAlphaMode::Ignore })

--- a/winrt/test.internal/graphics/PixelShaderEffectUnitTests.cpp
+++ b/winrt/test.internal/graphics/PixelShaderEffectUnitTests.cpp
@@ -153,7 +153,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         auto effect = Make<PixelShaderEffect>(nullptr, nullptr, sharedState.Get());
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
 
         // This should have passed the constant buffer through to D2D.
         Assert::AreEqual(constants, f.EffectPropertyValues[(int)PixelShaderEffectProperty::Constants]);
@@ -253,7 +253,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         ThrowIfFailed(properties->Insert(HStringReference(L"foo").Get(), Make<Nullable<int>>(3).Get(), &replaced));
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
 
         // This should have passed the constant buffer containing 3 through to D2D.
         auto& d2dConstants = f.GetEffectPropertyValue<int>(PixelShaderEffectProperty::Constants);
@@ -281,7 +281,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         ThrowIfFailed(effect->put_MaxSamplerOffset(23));
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
 
         // This should have passed the coordinate mapping state through to D2D.
         auto& d2dMapping = f.GetEffectPropertyValue<CoordinateMappingState>(PixelShaderEffectProperty::CoordinateMapping);
@@ -318,7 +318,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         ThrowIfFailed(effect->put_Source2Interpolation(CanvasImageInterpolation::Anisotropic));
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
 
         // This should have passed the interpolation mode state through to D2D.
         auto& d2dInterpolation = f.GetEffectPropertyValue<SourceInterpolationState>(PixelShaderEffectProperty::SourceInterpolation);

--- a/winrt/test.internal/graphics/PixelShaderEffectUnitTests.cpp
+++ b/winrt/test.internal/graphics/PixelShaderEffectUnitTests.cpp
@@ -152,7 +152,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         auto effect = Make<PixelShaderEffect>(nullptr, nullptr, sharedState.Get());
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0, nullptr);
 
         // This should have passed the constant buffer through to D2D.
         Assert::AreEqual(constants, f.EffectPropertyValues[(int)PixelShaderEffectProperty::Constants]);
@@ -252,7 +252,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         ThrowIfFailed(properties->Insert(HStringReference(L"foo").Get(), Make<Nullable<int>>(3).Get(), &replaced));
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0, nullptr);
 
         // This should have passed the constant buffer containing 3 through to D2D.
         auto& d2dConstants = f.GetEffectPropertyValue<int>(PixelShaderEffectProperty::Constants);
@@ -280,7 +280,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         ThrowIfFailed(effect->put_MaxSamplerOffset(23));
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0, nullptr);
 
         // This should have passed the coordinate mapping state through to D2D.
         auto& d2dMapping = f.GetEffectPropertyValue<CoordinateMappingState>(PixelShaderEffectProperty::CoordinateMapping);
@@ -317,7 +317,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         ThrowIfFailed(effect->put_Source2Interpolation(CanvasImageInterpolation::Anisotropic));
 
         // Realize the effect.
-        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr);
+        effect->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0, nullptr);
 
         // This should have passed the interpolation mode state through to D2D.
         auto& d2dInterpolation = f.GetEffectPropertyValue<SourceInterpolationState>(PixelShaderEffectProperty::SourceInterpolation);
@@ -353,7 +353,7 @@ TEST_CLASS(PixelShaderEffectUnitTests)
         Assert::AreEqual(f.CanvasDevice.Get()->Release(), 1ul);
 
         ComPtr<ID2D1Image> image;
-        ThrowIfFailed(As<ICanvasImageInterop>(effect)->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), GetD2DImageFlags::None, 0, nullptr, &image));
+        ThrowIfFailed(As<ICanvasImageInterop>(effect)->GetD2DImage(f.CanvasDevice.Get(), f.DeviceContext.Get(), WIN2D_GET_D2D_IMAGE_FLAGS_NONE, 0, nullptr, &image));
 
         f.CanvasDevice.Get()->AddRef();
 


### PR DESCRIPTION
## Background and motivation

Win2D is an amazing library that makes it really easy for everyone to build custom effects pipelines and implement all sorts of cool visual effects, especially in combination with the Composition layer. APIs such as `CanvasControl`, `CanvasAnimatedControl`, `CanvasImageSource` and `CompositionDrawingSurface` make it very convenient for developers to just get a ready to use D2D canvas they can use to create anything they need, and there's lots of built-in APIs to draw images, strokes, shapes, text, and to apply effects. There is a limitation though in cases where advanced users had the need to implement custom effects, as that's currently not supported. That is, there is no way to implement an `ICanvasImage` outside of Win2D itself.

The only way to add custom rendering steps into a drawing session is via the built-in `PixelShaderEffect`, which does allow developers to at least draw custom D2D1 pixel shaders, but that comes with its own set of limitations:
- It is restricted to D2D1 pixel shaders using Shader Model 4
- It uses reflection to dynamically create bindings for variables
  - This adds unnecessary overhead during initialization
  - This also prevents users from efficiently set the whole constant buffer in one go
  - This also limits the possible types that can be used in fields (eg. no custom struct types)
- It doesn't support D2D1 resource textures
- It doesn't support fully customizable D2D1 draw transform mappings

That is: `PixelShaderEffect` itself has several drawbacks, and after experimenting with it for a bit I came to the conclusion that there isn't really a way to address them without introducing any breaking changes (which are of course out of question). Not just that, even that wouldn't actually address the core of the problem: there should be a way to **allow any developer to freely extend Win2D's functionality and to implement their own fully customizable effects that can then interop seamlessly with Win2D**.

There is a way to do Win2D/D2D interop ([as documented here](https://microsoft.github.io/Win2D/WinUI2/html/Interop.htm)), which is great and can help fill some gaps, but that still isn't an ideal scenario, for two main reasons:

- It doesn't allow developers to author their own `ICanvasImage` effects that consumers can then easily use just like any other Win2D built-in effect. That includes eg. passing them to a `DrawImage` call on a drawing session, or using them as inputs for other effects. Retrieving an `ID2D1DeviceContext1` from a `CanvasDrawingSession` object would only allow developers to inject their own rendering logic right there, but it wouldn't enable them to author and publish custom effects that would feel on par with Win2D's ones, thus greatly limiting them and making them not feel "on the same level" as the built-in effects.
- It wouldn't work with some of the other APIs working with `ICanvasImage`, such as the static `CanvasImage.SaveAsync`.

This proposal aims to fully address all of these concerns, and to enable all developers to author custom `ICanvasImage`-s.

## Proposed API

The way Win2D handles input `ICanvasImage`-s from any of the public APIs is by casting them to `ICanvasImageInternal`, which is a private, C++ API that exposes the necessary extension points to interoperate with these images. The proposal extends this by adding a three publicly documented APIs that developers will be able to use for custom effects.

Three new APIs will be added to `ABI.Microsoft.Graphics.Canvas` in `winrt/published/Microsoft.Graphics.Canvas.native.h`:

```cpp
// COM interface for external, Win2D-compatible effects
class __declspec(uuid("E042D1F7-F9AD-4479-A713-67627EA31863"))
ICanvasImageInterop : public IUnknown
{
public:
    IFACEMETHOD(GetDevice)(ICanvasDevice** device) = 0;

    IFACEMETHOD(GetD2DImage)(
        ICanvasDevice* device,
        ID2D1DeviceContext* deviceContext,
        GetD2DImageFlags flags,
        float targetDpi,
        float* realizeDpi,
        ID2D1Image** ppImage) = 0;
};

// Options for fine-tuning the behavior of ICanvasImageInterop::GetD2DImage.
typedef enum GetD2DImageFlags
{
    None = 0,
    ReadDpiFromDeviceContext = 1,    // Ignore the targetDpi parameter - read DPI from deviceContext instead
    AlwaysInsertDpiCompensation = 2, // Ignore the targetDpi parameter - always insert DPI compensation
    NeverInsertDpiCompensation = 4,  // Ignore the targetDpi parameter - never insert DPI compensation
    MinimalRealization = 8,          // Do the bare minimum to get back an ID2D1Image - no validation or recursive realization
    AllowNullEffectInputs = 16,      // Allow partially configured effect graphs where some inputs are null
    UnrealizeOnFailure = 32,         // If an input is invalid, unrealize the effect and set the output image to null
} GetD2DImageFlags;

// Enables external objects implementing ICanvasImage to fully implement its APIs
extern "C" __declspec(nothrow, dllexport) HRESULT __stdcall GetBoundsForICanvasImageInterop(
    ICanvasResourceCreator* resourceCreator,
    ICanvasImageInterop* image,
    ABI::Windows::Foundation::Numerics::Matrix3x2 const* transform,
    ABI::Windows::Foundation::Rect* rect);
```

The reason for these three APIs is:
- `GetD2DImage` matches the internal `ICanvasImageInternal::GetD2DImage` (though with a stable COM ABI) and is used to retrieve an `ID2D1Image` by Win2D APIs receiving an `ICanvasImage`, so they can then draw them onto a device context.
- `GetDevice` is necessary when custom `ICanvasImage` effects implementing this interface are receiving other effects as sources: this way they can `QueryInterface` those input effects (which might either be Win2D effects or other custom ones) to `ICanvasImageInterop` and then get the device that was used to realize them, if one is available, to ensure it matches the one the current effect is realized on. This matches what Win2D also does internally for its own effects, and is a necessary extension points to allow custom effects to easily interop with Win2D effects and custom effects as their own inputs.
- `GetBoundsForICanvasImageInterop` is needed so that external objects can implement the `ICanvasImage` APIs correctly. To do this, they need'd access to a device context, which can only be retrieved internally. To avoid exposing internal implementation details and to make the code simple, this API allows external objects to instead easily leverage the same exact infrastructure that all images are using internally. They'd just call this, and Win2D would run the same logic as other images.

## Usage examples

Implementing a fully custom effect is a bit involved, but a full work in progress extension package to support this in ComputeSharp.D2D1 is available at https://github.com/Sergio0694/ComputeSharp/tree/dev/win2d-effect. This is a UWP-specific package (I will also provide a WinUI 3 one) that depends on ComputeSharp.D2D, which will expose a new `PixelShaderEffect<T>` effect that will be specifically tailored to support D2D1 pixel shaders authored with ComputeSharp.D2D1. This will give developers the ability to write and use custom pixel shaders extremely easily in their native Windows applications 🚀

Here's a short video showcasing a proof of concept effect powered by ComputeSharp.D2D1.Uwp:

https://user-images.githubusercontent.com/10199417/196773696-7a34da5f-416c-4ae4-b85d-7f6f15bd66d1.mp4

This runs in a Win2D `CanvasAnimatedControl`. The same effect also works seamlessly as input for other Win2D effects, as well as using other Win2D effects as its own inputs. This is why both those APIs are needed, to get parity with Win2D's implementation.

## Alternative Designs

As mentioned above, it would also be possible to extend `PixelShaderEffect`, but:
- There is no way to do that to fill all those gaps and also not make breaking changes
- It would still limit how authors would setup a custom effect
- It would only enable D2D1 pixel shader effects, not truly custom D2D effects of any kind

## Risks

Relatively low: this only adds a COM API in the public header, and no new WinRT APIs. The internal implementation will keep the same behavior for all existing code, and will only use the new interface as a fallback, when one is available. That is, this should cause no functional changes at all for existing code, and it only affects the few public code paths taking an `ICanvasImage` object (eg. `CanvasDrawingSession.DrawImage`).