### PR TITLE
Set Direct3D feature level 11.1

### DIFF
--- a/winrt/lib/drawing/CanvasDevice.cpp
+++ b/winrt/lib/drawing/CanvasDevice.cpp
@@ -49,7 +49,7 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
         }
 
-        auto featureLevels = { D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_9_3, D3D_FEATURE_LEVEL_9_2, D3D_FEATURE_LEVEL_9_1 };
+        D3D_FEATURE_LEVEL featureLevels[7] { D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_9_3, D3D_FEATURE_LEVEL_9_2, D3D_FEATURE_LEVEL_9_1 };
         ComPtr<ID3D11Device> createdDevice;
         if (SUCCEEDED(D3D11CreateDevice(
             NULL, // adapter

--- a/winrt/lib/drawing/CanvasDevice.cpp
+++ b/winrt/lib/drawing/CanvasDevice.cpp
@@ -49,14 +49,15 @@ namespace ABI { namespace Microsoft { namespace Graphics { namespace Canvas
             deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
         }
 
+        auto featureLevels = { D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_9_3, D3D_FEATURE_LEVEL_9_2, D3D_FEATURE_LEVEL_9_1 };
         ComPtr<ID3D11Device> createdDevice;
         if (SUCCEEDED(D3D11CreateDevice(
             NULL, // adapter
             driverType,
             NULL, // software handle
             deviceFlags,
-            NULL, // feature level array
-            0,  // feature level count
+            featureLevels, // feature level array
+            ARRAYSIZE(featureLevels),  // feature level count
             D3D11_SDK_VERSION,
             &createdDevice,
             NULL,


### PR DESCRIPTION
Without Direct3D feature level array, I found that out variable (pFeatureLevel) is D3D_FEATURE_LEVEL_11_0.

In the official Direct2D documentation, featureLevels were created from 11.1 to 9.1 and provided to D3D11CreateDevice. This results out variable pFeatureLevel sets D3D_FEATURE_LEVEL_11_1.

I don't know how this will work, but it doesn't look bad using 11.1.